### PR TITLE
[bluez] Make AVRCP version and features configurable. Contributes to JB#...

### DIFF
--- a/rpm/AVRCP-feature-configuration.patch
+++ b/rpm/AVRCP-feature-configuration.patch
@@ -1,0 +1,304 @@
+diff -Naur bluez.orig/audio/avctp.c bluez/audio/avctp.c
+--- bluez.orig/audio/avctp.c	2013-10-04 14:22:45.443381317 +0300
++++ bluez/audio/avctp.c	2013-10-05 10:01:06.665553503 +0300
+@@ -506,8 +506,7 @@
+ 	handler = find_handler(handlers, avc->opcode);
+ 	if (!handler) {
+ 		DBG("handler not found for 0x%02x", avc->opcode);
+-		packet_size += avrcp_handle_vendor_reject(&code, operands);
+-		avc->code = code;
++		avc->code = AVC_CTYPE_NOT_IMPLEMENTED;
+ 		goto done;
+ 	}
+ 
+diff -Naur bluez.orig/audio/avrcp.c bluez/audio/avrcp.c
+--- bluez.orig/audio/avrcp.c	2013-10-04 14:22:45.439381317 +0300
++++ bluez/audio/avrcp.c	2013-10-05 10:00:09.261555581 +0300
+@@ -178,6 +178,32 @@
+ 	IEEEID_BTSIG,
+ };
+ 
++#define DEFAULT_PROTOCOL_VERSION 0
++
++struct avrcp_ct_config {
++	gboolean enabled;
++	uint16_t avrcp_ver;
++	uint16_t disabled_features;
++};
++
++struct avrcp_tg_config {
++	gboolean enabled;
++	uint16_t avrcp_ver;
++	uint16_t disabled_features;
++};
++
++struct avrcp_ct_config avrcp_ct_config = {
++	TRUE,
++	DEFAULT_PROTOCOL_VERSION,
++	0
++};
++
++struct avrcp_tg_config avrcp_tg_config = {
++	TRUE,
++	DEFAULT_PROTOCOL_VERSION,
++	0
++};
++
+ static void register_volume_notification(struct avrcp_player *player);
+ 
+ static sdp_record_t *avrcp_ct_record(void)
+@@ -195,6 +221,10 @@
+ 						AVRCP_FEATURE_CATEGORY_3 |
+ 						AVRCP_FEATURE_CATEGORY_4 );
+ 
++	if (avrcp_ct_config.avrcp_ver != DEFAULT_PROTOCOL_VERSION)
++		avrcp_ver = avrcp_ct_config.avrcp_ver;
++	feat &= ~avrcp_ct_config.disabled_features;
++
+ 	record = sdp_record_alloc();
+ 	if (!record)
+ 		return NULL;
+@@ -264,6 +294,10 @@
+ 					AVRCP_FEATURE_CATEGORY_4 |
+ 					AVRCP_FEATURE_PLAYER_SETTINGS );
+ 
++	if (avrcp_tg_config.avrcp_ver != DEFAULT_PROTOCOL_VERSION)
++		avrcp_ver = avrcp_tg_config.avrcp_ver;
++	feat &= ~avrcp_tg_config.disabled_features;
++
+ 	record = sdp_record_alloc();
+ 	if (!record)
+ 		return NULL;
+@@ -1214,7 +1248,6 @@
+ 			avctp_unregister_pdu_handler(player->handler);
+ 			player->handler = 0;
+ 		}
+-
+ 		break;
+ 	case AVCTP_STATE_CONNECTING:
+ 		player->session = avctp_connect(&dev->src, &dev->dst);
+@@ -1267,6 +1300,108 @@
+ 	avctp_disconnect(session);
+ }
+ 
++static void setup_avrcp_tg_config(GKeyFile *config,
++				gboolean *enabled,
++				uint16_t *version,
++				uint16_t *disabled_features)
++{
++	GError *err = NULL;
++	gboolean b;
++	char **list;
++	char *s;
++	int i;
++
++	if (!config)
++		return;
++
++	b = g_key_file_get_boolean(config, "AVRCP", "EnableTarget", &err);
++	if (err) {
++		DBG("audio.conf: %s", err->message);
++		g_error_free(err);
++		err = NULL;
++	} else
++		*enabled = b;
++
++	s = g_key_file_get_string(config, "AVRCP", "TargetVersion", &err);
++	if (err) {
++		DBG("audio.conf: %s", err->message);
++		g_error_free(err);
++		err = NULL;
++	} else {
++		*version = strtol(s, NULL, 16);
++		g_free(s);
++	}
++
++	list = g_key_file_get_string_list(config,
++					"AVRCP", "DisableTargetFeatures",
++					NULL, NULL);
++	
++	*disabled_features = 0;
++	for (i = 0; list && list[i] != NULL; i++) {
++		if (g_str_equal(list[i], "Category1"))
++			*disabled_features |= AVRCP_FEATURE_CATEGORY_1;
++		else if (g_str_equal(list[i], "Category2"))
++			*disabled_features |= AVRCP_FEATURE_CATEGORY_2;
++		else if (g_str_equal(list[i], "Category3"))
++			*disabled_features |= AVRCP_FEATURE_CATEGORY_3;
++		else if (g_str_equal(list[i], "Category4"))
++			*disabled_features |= AVRCP_FEATURE_CATEGORY_4;
++		else if (g_str_equal(list[i], "PlayerSettings"))
++			*disabled_features |= AVRCP_FEATURE_PLAYER_SETTINGS;
++	}
++	g_strfreev(list);
++}
++
++static void setup_avrcp_ct_config(GKeyFile *config,
++				gboolean *enabled,
++				uint16_t *version,
++				uint16_t *disabled_features)
++{
++	GError *err = NULL;
++	gboolean b;
++	char **list;
++	char *s;
++	int i;
++
++	if (!config)
++		return;
++
++	b = g_key_file_get_boolean(config, "AVRCP", "EnableControl", &err);
++	if (err) {
++		DBG("audio.conf: %s", err->message);
++		g_error_free(err);
++		err = NULL;
++	} else
++		*enabled = b;
++
++	s = g_key_file_get_string(config, "AVRCP", "ControlVersion", &err);
++	if (err) {
++		DBG("audio.conf: %s", err->message);
++		g_error_free(err);
++		err = NULL;
++	} else {
++		*version = strtol(s, NULL, 16);
++		g_free(s);
++	}
++
++	list = g_key_file_get_string_list(config,
++					"AVRCP", "DisableControlFeatures",
++					NULL, NULL);
++	
++	*disabled_features = 0;
++	for (i = 0; list && list[i] != NULL; i++) {
++		if (g_str_equal(list[i], "Category1"))
++			*disabled_features |= AVRCP_FEATURE_CATEGORY_1;
++		else if (g_str_equal(list[i], "Category2"))
++			*disabled_features |= AVRCP_FEATURE_CATEGORY_2;
++		else if (g_str_equal(list[i], "Category3"))
++			*disabled_features |= AVRCP_FEATURE_CATEGORY_3;
++		else if (g_str_equal(list[i], "Category4"))
++			*disabled_features |= AVRCP_FEATURE_CATEGORY_4;
++	}
++	g_strfreev(list);
++}
++
+ int avrcp_register(DBusConnection *conn, const bdaddr_t *src, GKeyFile *config)
+ {
+ 	sdp_record_t *record;
+@@ -1282,47 +1417,61 @@
+ 			g_error_free(err);
+ 		} else
+ 			master = tmp;
++
++		setup_avrcp_tg_config(config,
++				&avrcp_tg_config.enabled,
++				&avrcp_tg_config.avrcp_ver,
++				&avrcp_tg_config.disabled_features);
++
++		setup_avrcp_ct_config(config,
++				&avrcp_ct_config.enabled,
++				&avrcp_ct_config.avrcp_ver,
++				&avrcp_ct_config.disabled_features);
+ 	}
+ 
+ 	server = g_new0(struct avrcp_server, 1);
+ 	if (!server)
+ 		return -ENOMEM;
+ 
+-	record = avrcp_tg_record();
+-	if (!record) {
+-		error("Unable to allocate new service record");
+-		g_free(server);
+-		return -1;
+-	}
+-
+-	if (add_record_to_server(src, record) < 0) {
+-		error("Unable to register AVRCP target service record");
+-		g_free(server);
+-		sdp_record_free(record);
+-		return -1;
+-	}
+-	server->tg_record_id = record->handle;
+-
+-	record = avrcp_ct_record();
+-	if (!record) {
+-		error("Unable to allocate new service record");
+-		g_free(server);
+-		return -1;
+-	}
+-
+-	if (add_record_to_server(src, record) < 0) {
+-		error("Unable to register AVRCP service record");
+-		sdp_record_free(record);
+-		g_free(server);
+-		return -1;
++	if (avrcp_tg_config.enabled) {
++
++		record = avrcp_tg_record();
++		if (!record) {
++			error("Unable to allocate new service record");
++			goto fail;
++		}
++
++		if (add_record_to_server(src, record) < 0) {
++			error("Unable to register AVRCP target service record");
++			sdp_record_free(record);
++			goto fail;
++		}
++		server->tg_record_id = record->handle;
++	}
++
++	if (avrcp_ct_config.enabled) {
++
++		record = avrcp_ct_record();
++		if (!record) {
++			error("Unable to allocate new service record");
++			goto fail;
++		}
++
++		if (add_record_to_server(src, record) < 0) {
++			error("Unable to register AVRCP service record");
++			sdp_record_free(record);
++			goto fail;
++		}
++		server->ct_record_id = record->handle;
++
+ 	}
+-	server->ct_record_id = record->handle;
+ 
+ 	if (avctp_register(src, master) < 0) {
+-		remove_record_from_server(server->ct_record_id);
+-		remove_record_from_server(server->tg_record_id);
+-		g_free(server);
+-		return -1;
++		if (avrcp_ct_config.enabled)
++			remove_record_from_server(server->ct_record_id);
++		if (avrcp_tg_config.enabled)
++			remove_record_from_server(server->tg_record_id);
++		goto fail;
+ 	}
+ 
+ 	bacpy(&server->src, src);
+@@ -1330,6 +1479,10 @@
+ 	servers = g_slist_append(servers, server);
+ 
+ 	return 0;
++
++fail:
++	g_free(server);
++	return -1;
+ }
+ 
+ static void player_destroy(gpointer data)
+@@ -1382,6 +1535,10 @@
+ 	struct avrcp_server *server;
+ 	struct avrcp_player *player;
+ 
++	/* Don't accept player if using an old version of the protocol */
++	if (avrcp_tg_config.avrcp_ver < 0x0103)
++		return NULL;
++
+ 	server = find_server(servers, src);
+ 	if (!server)
+ 		return NULL;

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -25,6 +25,7 @@ Patch5:     install-test-scripts.patch
 Patch6:     0001-Adding-snowball-target-and-line-disc.patch
 Patch7:     allow-ofono-communication.patch
 Patch8:     telephony-feature-configuration.patch
+Patch9:     AVRCP-feature-configuration.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -161,6 +162,8 @@ This package provides default configs for bluez
 %patch7 -p1
 # telephony-feature-configuration.patch
 %patch8 -p1
+# AVRCP-feature-configuration.patch
+%patch9 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
...10051

In order to have better control over what is advertised over SDP and
what features are made available, added parsing of AVRCP configuration
entries.

TG and CT can be individually disabled; if TG version is specified
to be below 0x0103, media player registrations will be rejected and
the related functionality is essentially disabled.
