### PR TITLE
[bluez] Last dialed number from cache file, don't make memory dial reque...

### DIFF
--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -28,6 +28,7 @@ Patch8:     telephony-feature-configuration.patch
 Patch9:     AVRCP-feature-configuration.patch
 Patch10:    bluetoothd-restart.patch
 Patch11:    statefs-battery-charge.patch
+Patch12:    telephony-last-dialed.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -170,6 +171,8 @@ This package provides default configs for bluez
 %patch10 -p1
 # statefs-battery-charge.patch
 %patch11 -p1
+# telephony-last-dialed.patch
+%patch12 -p1
 # >> setup
 # << setup
 

--- a/rpm/telephony-last-dialed.patch
+++ b/rpm/telephony-last-dialed.patch
@@ -1,0 +1,225 @@
+diff -Naur bluez.orig/audio/manager.c bluez/audio/manager.c
+--- bluez.orig/audio/manager.c	2013-10-08 12:21:07.843301187 +0300
++++ bluez/audio/manager.c	2013-10-08 12:47:38.515246882 +0300
+@@ -192,6 +192,21 @@
+ 	return batt;
+ }
+ 
++static gchar* telephony_last_dialed_number_path(GKeyFile *config)
++{
++	GError *e = NULL;
++	char *s;
++
++	s = g_key_file_get_string(config, "Telephony", "LastDialedNumber", &e);
++	if (e) {
++		DBG("audio.conf: %s", e->message);
++		g_error_free(e);
++		return NULL;
++	}
++
++	return s;
++}
++
+ static struct audio_adapter *find_adapter(GSList *list,
+ 					struct btd_adapter *btd_adapter)
+ {
+@@ -953,15 +968,17 @@
+ 		uint32_t disabled_features;
+ 		enum batt_info_source batt;
+ 		void *batt_param = NULL;
++		gchar *last_path = NULL;
+ 
+ 		/* telephony driver already initialized*/
+ 		if (telephony == TRUE)
+ 			return;
+ 		setup_telephony_ag_features(config, &disabled_features);
+ 		batt = telephony_battery_info_source(config, &batt_param);
+-		telephony_init(disabled_features, batt, batt_param);
+-		if (batt_param != NULL)
+-			g_free(batt_param);
++		last_path = telephony_last_dialed_number_path(config);
++		telephony_init(disabled_features, batt, batt_param, last_path);
++		g_free(batt_param);
++		g_free(last_path);
+ 		telephony = TRUE;
+ 		return;
+ 	}
+diff -Naur bluez.orig/audio/telephony-dummy.c bluez/audio/telephony-dummy.c
+--- bluez.orig/audio/telephony-dummy.c	2013-10-08 12:21:07.839301187 +0300
++++ bluez/audio/telephony-dummy.c	2013-10-08 12:43:17.303255800 +0300
+@@ -410,7 +410,7 @@
+ };
+ 
+ int telephony_init(uint32_t disabled_features, enum batt_info_source batt,
+-		void *batt_param)
++		void *batt_param, gchar *last_number_path)
+ {
+ 	uint32_t features = AG_FEATURE_REJECT_A_CALL |
+ 				AG_FEATURE_ENHANCED_CALL_STATUS |
+@@ -423,6 +423,9 @@
+ 	if (batt != BATT_INFO_DEFAULT)
+ 		DBG("Ignoring non-default battery info source. ");
+ 
++	if (last_number_path != NULL)
++		DBG("Ignoring non-NULL last number path. ");
++
+ 	connection = dbus_bus_get(DBUS_BUS_SYSTEM, NULL);
+ 
+ 	if (g_dbus_register_interface(connection, TELEPHONY_DUMMY_PATH,
+diff -Naur bluez.orig/audio/telephony.h bluez/audio/telephony.h
+--- bluez.orig/audio/telephony.h	2013-10-08 12:21:07.839301187 +0300
++++ bluez/audio/telephony.h	2013-10-08 12:43:30.719255342 +0300
+@@ -251,5 +251,5 @@
+ }
+ 
+ int telephony_init(uint32_t disabled_features, enum batt_info_source batt_info,
+-		void *batt_info_param);
++		void *batt_info_param, gchar *last_number_path);
+ void telephony_exit(void);
+diff -Naur bluez.orig/audio/telephony-maemo5.c bluez/audio/telephony-maemo5.c
+--- bluez.orig/audio/telephony-maemo5.c	2013-10-08 12:21:07.843301187 +0300
++++ bluez/audio/telephony-maemo5.c	2013-10-08 12:42:54.839256566 +0300
+@@ -2030,7 +2030,7 @@
+ }
+ 
+ int telephony_init(uint32_t disabled_features, enum batt_info_source batt,
+-		void *batt_param)
++		void *batt_param, gchar *last_number_path)
+ {
+ 	const char *battery_cap = "battery";
+ 	uint32_t features = AG_FEATURE_EC_ANDOR_NR |
+@@ -2046,6 +2046,9 @@
+ 	if (batt != BATT_INFO_DEFAULT)
+ 		DBG("Ignoring non-default battery info source. ");
+ 
++	if (last_number_path != NULL)
++		DBG("Ignoring non-NULL last number path. ");
++
+ 	connection = dbus_bus_get(DBUS_BUS_SYSTEM, NULL);
+ 
+ 	if (!dbus_connection_add_filter(connection, signal_filter,
+diff -Naur bluez.orig/audio/telephony-maemo6.c bluez/audio/telephony-maemo6.c
+--- bluez.orig/audio/telephony-maemo6.c	2013-10-08 12:21:07.843301187 +0300
++++ bluez/audio/telephony-maemo6.c	2013-10-08 12:42:33.103257309 +0300
+@@ -2116,7 +2116,7 @@
+ }
+ 
+ int telephony_init(uint32_t disabled_features, enum batt_info_source batt,
+-		void *batt_param)
++		void *batt_param, gchar *last_number_path)
+ {
+ 	const char *battery_cap = "battery";
+ 	uint32_t features = AG_FEATURE_EC_ANDOR_NR |
+@@ -2135,6 +2135,9 @@
+ 	if (batt != BATT_INFO_DEFAULT)
+ 		DBG("Ignoring non-default battery info source. ");
+ 
++	if (last_number_path != NULL)
++		DBG("Ignoring non-NULL last number path. ");
++
+ 	connection = dbus_bus_get(DBUS_BUS_SYSTEM, NULL);
+ 
+ 	add_watch(NULL, NULL, CSD_CALL_INTERFACE, NULL);
+diff -Naur bluez.orig/audio/telephony-ofono.c bluez/audio/telephony-ofono.c
+--- bluez.orig/audio/telephony-ofono.c	2013-10-08 12:21:07.839301187 +0300
++++ bluez/audio/telephony-ofono.c	2013-10-08 13:30:25.451651209 +0300
+@@ -58,6 +58,7 @@
+ static DBusConnection *connection = NULL;
+ static char *modem_obj_path = NULL;
+ static char *last_dialed_number = NULL;
++static gchar *last_dialed_number_path = NULL;
+ static GSList *calls = NULL;
+ static GSList *watches = NULL;
+ static GSList *pending = NULL;
+@@ -198,11 +199,34 @@
+ {
+ 	DBG("telephony-ofono: last dialed number request");
+ 
+-	if (last_dialed_number)
+-		telephony_dial_number_req(telephony_device, last_dialed_number);
+-	else
+-		telephony_last_dialed_number_rsp(telephony_device,
+-				CME_ERROR_NOT_ALLOWED);
++	/* If a path is given, prefer that to the number spied from
++	   ofono signals */
++	if (last_dialed_number_path != NULL) {
++		gchar *buf = NULL;
++		GError *err = NULL;
++
++		if (g_file_get_contents(last_dialed_number_path,
++						&buf, NULL, &err)) {
++			DBG("Dialing last dialed number '%s'", buf);
++			telephony_dial_number_req(telephony_device, buf);
++			g_free(buf);
++		} else {
++			DBG("Failed to read last dialed number from '%s': %s",
++				last_dialed_number_path, err->message);
++			telephony_last_dialed_number_rsp(telephony_device,
++							CME_ERROR_NOT_ALLOWED);
++			g_error_free(err);
++		}
++
++	} else {
++		if (last_dialed_number)
++			telephony_dial_number_req(telephony_device,
++						last_dialed_number);
++		else
++			telephony_last_dialed_number_rsp(telephony_device,
++							CME_ERROR_NOT_ALLOWED);
++	}
++
+ }
+ 
+ static int send_method_call(const char *dest, const char *path,
+@@ -395,6 +419,22 @@
+ 		return;
+ 	}
+ 
++	if(!number || *number == '\0') {
++		telephony_dial_number_rsp(telephony_device,
++					CME_ERROR_AG_FAILURE);
++		return;
++	}
++
++	/* Block memory dialing here; more proper would be to wait for
++	   ofono D-Bus reply, but I think that'd need audio device
++	   refcounting so that it doesn't potentially disappear while
++	   we wait for D-Bus reply. */
++	if (*number == '>') {
++		telephony_dial_number_rsp(telephony_device,
++					CME_ERROR_AG_FAILURE);
++		return;
++	}
++
+ 	if (!strncmp(number, "*31#", 4)) {
+ 		number += 4;
+ 		clir = "enabled";
+@@ -1593,7 +1633,7 @@
+ }
+ 
+ int telephony_init(uint32_t disabled_features, enum batt_info_source batt,
+-		void *batt_param)
++		void *batt_param, gchar *last_number_path)
+ {
+ 	uint32_t features = AG_FEATURE_EC_ANDOR_NR |
+ 				AG_FEATURE_INBAND_RINGTONE |
+@@ -1654,6 +1694,9 @@
+ 	if (ret < 0)
+ 		return ret;
+ 
++	if (last_number_path)
++		last_dialed_number_path = g_strdup(last_number_path);
++
+ 	DBG("telephony_init() successfully");
+ 
+ 	telephony_ready_ind(features, ofono_indicators, BTRH_NOT_SUPPORTED,
+@@ -1684,6 +1727,9 @@
+ 	g_free(last_dialed_number);
+ 	last_dialed_number = NULL;
+ 
++	g_free(last_dialed_number_path);
++	last_dialed_number_path = NULL;
++
+ 	if (modem_obj_path)
+ 		modem_removed(modem_obj_path);
+ 


### PR DESCRIPTION
...sts. Fixes JB#10607, contributes to JB#10628.

Instead of looking at the internal variable, check the last dialed number by reading a file if a path is given in the configuration file.

Reject dial attempts where the number starts with '>' (memory dialing) as ofono dial method does not support those. 
