### PR TITLE
[bluez] Call holding ofono API fix. Fixes JB#11148.

### DIFF
--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -31,6 +31,7 @@ Patch11:    statefs-battery-charge.patch
 Patch12:    telephony-last-dialed.patch
 Patch13:    telephony-signal-strength-indicator.patch
 Patch14:    telephony-call-hold-handling.patch
+Patch15:    telephony-call-hold-handling-take-two.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -179,6 +180,8 @@ This package provides default configs for bluez
 %patch13 -p1
 # telephony-call-hold-handling.patch
 %patch14 -p1
+# telephony-call-hold-handling-take-two.patch
+%patch15 -p1
 # >> setup
 # << setup
 

--- a/rpm/telephony-call-hold-handling-take-two.patch
+++ b/rpm/telephony-call-hold-handling-take-two.patch
@@ -1,0 +1,55 @@
+diff -Naur bluez.orig/audio/telephony-ofono.c bluez/audio/telephony-ofono.c
+--- bluez.orig/audio/telephony-ofono.c	2013-10-15 12:42:36.876246117 +0300
++++ bluez/audio/telephony-ofono.c	2013-10-15 12:42:46.752245746 +0300
+@@ -301,6 +301,24 @@
+ 						NULL, NULL, DBUS_TYPE_INVALID);
+ }
+ 
++static int release_swap_calls(void)
++{
++	DBG("%s", modem_obj_path);
++	return send_method_call(OFONO_BUS_NAME, modem_obj_path,
++						OFONO_VCMANAGER_INTERFACE,
++						"ReleaseAndSwap",
++						NULL, NULL, DBUS_TYPE_INVALID);
++}
++
++static int hold_answer_calls(void)
++{
++	DBG("%s", modem_obj_path);
++	return send_method_call(OFONO_BUS_NAME, modem_obj_path,
++						OFONO_VCMANAGER_INTERFACE,
++						"HoldAndAnswer",
++						NULL, NULL, DBUS_TYPE_INVALID);
++}
++
+ static int split_call(struct voice_call *call)
+ {
+ 	DBG("%s", modem_obj_path);
+@@ -608,8 +626,15 @@
+ 			if (release_call(call) != 0)
+ 				cme_err = CME_ERROR_AG_FAILURE;
+ 		} else {
+-			if (release_answer_calls() != 0)
+-				cme_err = CME_ERROR_AG_FAILURE;
++			call = find_vc_with_status(CALL_STATUS_WAITING);
++
++			if (call) {
++				if (release_answer_calls() != 0)
++					cme_err = CME_ERROR_AG_FAILURE;
++			} else {
++				if (release_swap_calls() != 0)
++					cme_err = CME_ERROR_AG_FAILURE;
++			}
+ 		}
+ 		break;
+ 	case '2':
+@@ -620,7 +645,7 @@
+ 			call = find_vc_with_status(CALL_STATUS_WAITING);
+ 
+ 			if (call) {
+-				if (answer_call(call))
++				if (hold_answer_calls())
+ 					cme_err = CME_ERROR_AG_FAILURE;
+ 			} else {
+ 				if (swap_calls())


### PR DESCRIPTION
Had to change the ofono API usage when call handling related AT commands are processed. 

From ofono documentation:

```
            void ReleaseAndSwap()

                    Releases currently active call (0 or more) and
                    activates any currently held calls. Please note that
                    if the current call is a multiparty call, then all
                    parties in the multi-party call will be released.


            void ReleaseAndAnswer()

                    Releases currently active call (0 or more) and
                    answers the currently waiting call. Please note that
                    if the current call is a multiparty call, then all
                    parties in the multi-party call will be released.


            void HoldAndAnswer()

                    Puts the current call (including multi-party calls) on
                    hold and answers the currently waiting call. Calling
                    this function when a user already has a both Active and
                    Held calls is invalid, since in GSM a user can have
                    only a single Held call at a time.
```
