### PR TITLE
[bluez] Reworked rfkill handling. Fixes JB#11460.

### DIFF
--- a/rpm/bluetoothd-handle-rfkilled-adapter.patch
+++ b/rpm/bluetoothd-handle-rfkilled-adapter.patch
@@ -1,78 +1,124 @@
 diff -Naur bluez.orig/plugins/hciops.c bluez/plugins/hciops.c
---- bluez.orig/plugins/hciops.c	2013-10-15 15:20:34.114248368 +0300
-+++ bluez/plugins/hciops.c	2013-10-16 09:41:17.129094322 +0300
-@@ -2931,6 +2931,28 @@
- 	}
+--- bluez.orig/plugins/hciops.c	2013-10-21 13:24:34.356945787 +0300
++++ bluez/plugins/hciops.c	2013-10-21 13:44:53.588894963 +0300
+@@ -2788,34 +2788,10 @@
+ 	hci_set_bit(PENDING_NAME, &dev->pending);
  }
  
-+static int hciops_init_adapter(int index, gboolean already_up)
+-static struct dev_info *init_device(int index, gboolean already_up)
++static void raise_adapter(int dd, int index)
+ {
+-	struct dev_info *dev;
+-	struct hci_dev_req dr;
+-	int dd;
+ 	pid_t pid;
+-
+-	DBG("hci%d", index);
+-
+-	dd = hci_open_dev(index);
+-	if (dd < 0) {
+-		error("Unable to open hci%d: %s (%d)", index,
+-						strerror(errno), errno);
+-		return NULL;
+-	}
+-
+-	if (index > max_dev) {
+-		max_dev = index;
+-		devs = g_realloc(devs, sizeof(devs[0]) * (max_dev + 1));
+-	}
+-
+-	dev = init_dev_info(index, dd, FALSE, already_up);
+-	init_pending(index);
+-	start_hci_dev(index);
+-
+-	/* Avoid forking if nothing else has to be done */
+-	if (already_up)
+-		return dev;
++	struct hci_dev_req dr;
+ 
+ 	/* Do initialization in the separate process */
+ 	pid = fork();
+@@ -2828,7 +2804,7 @@
+ 					index, strerror(errno), errno);
+ 		default:
+ 			DBG("child %d forked", pid);
+-			return dev;
++			return;
+ 	}
+ 
+ 	memset(&dr, 0, sizeof(dr));
+@@ -2855,6 +2831,55 @@
+ 	exit(1);
+ }
+ 
++static int hciops_adapter_up(int index)
 +{
-+	struct dev_info *dev;
++	int dd;
 +
-+	dev = init_device(index, already_up);
-+	if (dev == NULL)
++	DBG("hci%d", index);
++
++	dd = hci_open_dev(index);
++	if (dd < 0) {
++		error("Unable to open hci%d: %s (%d)", index,
++						strerror(errno), errno);
 +		return -1;
++	}
 +
-+	if (!dev->already_up)
-+		return 0;
-+
-+	init_conn_list(index);
-+
-+	dev->pending = 0;
-+	hci_set_bit(PENDING_VERSION, &dev->pending);
-+	hci_send_cmd(dev->sk, OGF_INFO_PARAM,
-+		OCF_READ_LOCAL_VERSION, 0, NULL);
-+	device_event(HCI_DEV_UP, index);
-+
++	raise_adapter(dd, index);
 +	return 0;
 +}
 +
- static gboolean init_known_adapters(gpointer user_data)
++static struct dev_info *init_device(int index, gboolean already_up)
++{
++	struct dev_info *dev;
++	int dd;
++
++	DBG("hci%d", index);
++
++	dd = hci_open_dev(index);
++	if (dd < 0) {
++		error("Unable to open hci%d: %s (%d)", index,
++						strerror(errno), errno);
++		return NULL;
++	}
++
++	if (index > max_dev) {
++		max_dev = index;
++		devs = g_realloc(devs, sizeof(devs[0]) * (max_dev + 1));
++	}
++
++	dev = init_dev_info(index, dd, FALSE, already_up);
++	init_pending(index);
++	start_hci_dev(index);
++
++	/* Avoid forking if nothing else has to be done */
++	if (already_up)
++		return dev;
++
++	raise_adapter(dd, index);
++
++	return dev;
++}
++
+ static void init_conn_list(int index)
  {
- 	struct hci_dev_list_req *dl;
-@@ -2959,25 +2981,9 @@
- 	}
- 
- 	for (i = 0; i < dl->dev_num; i++, dr++) {
--		struct dev_info *dev;
- 		gboolean already_up;
--
- 		already_up = hci_test_bit(HCI_UP, &dr->dev_opt);
--
--		dev = init_device(dr->dev_id, already_up);
--		if (dev == NULL)
--			continue;
--
--		if (!dev->already_up)
--			continue;
--
--		init_conn_list(dr->dev_id);
--
--		dev->pending = 0;
--		hci_set_bit(PENDING_VERSION, &dev->pending);
--		hci_send_cmd(dev->sk, OGF_INFO_PARAM,
--					OCF_READ_LOCAL_VERSION, 0, NULL);
--		device_event(HCI_DEV_UP, dr->dev_id);
-+		hciops_init_adapter(dr->dev_id, already_up);
- 	}
- 
- 	g_free(dl);
-@@ -3925,6 +3931,7 @@
+ 	struct dev_info *dev = &devs[index];
+@@ -3925,6 +3950,7 @@
  	.remove_remote_oob_data = hciops_remove_remote_oob_data,
  	.confirm_name = hciops_confirm_name,
  	.load_ltks = hciops_load_ltks,
-+	.initialize = hciops_init_adapter
++	.adapter_up = hciops_adapter_up
  };
  
  static int hciops_init(void)
 diff -Naur bluez.orig/plugins/mgmtops.c bluez/plugins/mgmtops.c
---- bluez.orig/plugins/mgmtops.c	2013-10-15 15:20:34.114248368 +0300
-+++ bluez/plugins/mgmtops.c	2013-10-16 09:46:42.525082098 +0300
+--- bluez.orig/plugins/mgmtops.c	2013-10-21 13:24:34.356945787 +0300
++++ bluez/plugins/mgmtops.c	2013-10-21 13:28:34.556935774 +0300
 @@ -2471,6 +2471,11 @@
  	return err;
  }
  
-+static int mgmtops_init_adapter(int index, gboolean already_up)
++static int mgmtops_adapter_up(int index)
 +{
 +	return -1; /* not implemented */
 +}
@@ -84,31 +130,31 @@ diff -Naur bluez.orig/plugins/mgmtops.c bluez/plugins/mgmtops.c
  	.remove_remote_oob_data = mgmt_remove_remote_oob_data,
  	.confirm_name = mgmt_confirm_name,
  	.load_ltks = mgmtops_load_ltks,
-+	.initialize = mgmtops_init_adapter
++	.adapter_up = mgmtops_adapter_up
  };
  
  static int mgmt_init(void)
 diff -Naur bluez.orig/src/adapter.c bluez/src/adapter.c
---- bluez.orig/src/adapter.c	2013-10-15 15:20:34.118248368 +0300
-+++ bluez/src/adapter.c	2013-10-16 09:40:15.817096625 +0300
+--- bluez.orig/src/adapter.c	2013-10-21 13:24:34.360945787 +0300
++++ bluez/src/adapter.c	2013-10-21 13:50:08.268881845 +0300
 @@ -3578,3 +3578,8 @@
  {
  	return adapter_ops->remove_remote_oob_data(adapter->dev_id, bdaddr);
  }
 +
-+int btd_adapter_initialize(int id)
++int btd_adapter_up(int id)
 +{
-+	return adapter_ops->initialize(id, FALSE);
++	return adapter_ops->adapter_up(id);
 +}
 diff -Naur bluez.orig/src/adapter.h bluez/src/adapter.h
---- bluez.orig/src/adapter.h	2013-10-15 15:20:34.118248368 +0300
-+++ bluez/src/adapter.h	2013-10-16 09:40:25.433096264 +0300
+--- bluez.orig/src/adapter.h	2013-10-21 13:24:34.364945786 +0300
++++ bluez/src/adapter.h	2013-10-21 13:47:27.884888531 +0300
 @@ -220,6 +220,8 @@
  	int (*confirm_name) (int index, bdaddr_t *bdaddr, uint8_t bdaddr_type,
  							gboolean name_known);
  	int (*load_ltks) (int index, GSList *keys);
 +
-+	int (*initialize) (int index, gboolean already_up);
++	int (*adapter_up) (int index);
  };
  
  int btd_register_adapter_ops(struct btd_adapter_ops *ops, gboolean priority);
@@ -117,19 +163,19 @@ diff -Naur bluez.orig/src/adapter.h bluez/src/adapter.h
  int btd_adapter_gatt_server_start(struct btd_adapter *adapter);
  void btd_adapter_gatt_server_stop(struct btd_adapter *adapter);
 +
-+int btd_adapter_initialize(int id);
++int btd_adapter_up(int id);
 diff -Naur bluez.orig/src/rfkill.c bluez/src/rfkill.c
---- bluez.orig/src/rfkill.c	2013-10-15 15:20:34.118248368 +0300
-+++ bluez/src/rfkill.c	2013-10-16 09:34:52.013108789 +0300
+--- bluez.orig/src/rfkill.c	2013-10-21 13:24:34.360945787 +0300
++++ bluez/src/rfkill.c	2013-10-21 13:48:10.124886770 +0300
 @@ -129,8 +129,12 @@
  		return TRUE;
  
  	adapter = manager_find_adapter_by_id(id);
 -	if (!adapter)
 +	if (!adapter) {
-+		DBG("Adapter %d rfkilled since start, initializing.", id);
-+		if (btd_adapter_initialize(id) != 0)
-+			DBG("Initializing adapter %d failed.", id);
++		DBG("Adapter %d rfkilled since start, raising.", id);
++		if (btd_adapter_up(id) != 0)
++			DBG("Raising adapter %d failed.", id);
  		return TRUE;
 +	}
  


### PR DESCRIPTION
Previous patch performed part of the initialization twice for
an rfkilled adapter, meaning that hci events were handled twice.
Modified so that on receiving an rfkill event only try to raise
the adapter up; other initialization has already been done as
part of initializing known adapters.
