### PR TITLE
[bluez] Fix freed pointer reference. Fixes JB#10268.

### DIFF
--- a/rpm/AVDTP-stream-abort-handling.patch
+++ b/rpm/AVDTP-stream-abort-handling.patch
@@ -1,0 +1,19 @@
+diff -Naur bluez.orig/audio/avdtp.c bluez/audio/avdtp.c
+--- bluez.orig/audio/avdtp.c	2013-10-22 09:36:17.622336701 +0300
++++ bluez/audio/avdtp.c	2013-10-22 13:44:21.245716272 +0300
+@@ -1113,6 +1113,15 @@
+ 
+ 	if (state == AVDTP_STATE_IDLE &&
+ 				g_slist_find(session->streams, stream)) {
++		DBG("Removing stream %p. ", stream);
++
++		/* Quick hack to deal with abort requests made by stream callbacks */
++		if (session->req && session->req->stream == stream) {
++			DBG("Resetting stream to NULL for request %p (session %p)",
++				session->req, session);
++			session->req->stream = NULL;
++		}
++
+ 		session->streams = g_slist_remove(session->streams, stream);
+ 		stream_free(stream);
+ 	}

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -33,6 +33,7 @@ Patch12:    telephony-signal-strength-indicator.patch
 Patch13:    telephony-call-hold-handling.patch
 Patch14:    telephony-call-hold-handling-take-two.patch
 Patch15:    bluetoothd-handle-rfkilled-adapter.patch
+Patch16:    AVDTP-stream-abort-handling.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -182,6 +183,8 @@ This package provides default configs for bluez
 %patch14 -p1
 # bluetoothd-handle-rfkilled-adapter.patch
 %patch15 -p1
+# AVDTP-stream-abort-handling.patch
+%patch16 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
It could happen that a callback function would request an abort when
stream state was changing to idle and the related structure would be
freed before abort response would arrive. Quick hack to prevent a
crash.
