### PR TITLE
[bluez] Use the last dialed number as memory location 1. Fixes JB#11611.

### DIFF
--- a/rpm/HFP-memory-dial-last-dialed-number.patch
+++ b/rpm/HFP-memory-dial-last-dialed-number.patch
@@ -1,0 +1,18 @@
+diff -Naur bluez.orig/audio/telephony-ofono.c bluez/audio/telephony-ofono.c
+--- bluez.orig/audio/telephony-ofono.c	2013-10-23 11:24:30.272434561 +0300
++++ bluez/audio/telephony-ofono.c	2013-10-23 18:15:43.819309051 +0300
+@@ -449,7 +449,13 @@
+ 		return;
+ 	}
+ 
+-	/* Block memory dialing here; more proper would be to wait for
++	/* Fake memory dialing for memory location one. */
++	if (!strcmp(number, ">1")) {
++		telephony_last_dialed_number_req(telephony_device);
++		return;
++	}
++
++	/* Block other memory dialing; more proper would be to wait for
+ 	   ofono D-Bus reply, but I think that'd need audio device
+ 	   refcounting so that it doesn't potentially disappear while
+ 	   we wait for D-Bus reply. */

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -34,6 +34,7 @@ Patch13:    telephony-call-hold-handling.patch
 Patch14:    telephony-call-hold-handling-take-two.patch
 Patch15:    bluetoothd-handle-rfkilled-adapter.patch
 Patch16:    AVDTP-stream-abort-handling.patch
+Patch17:    HFP-memory-dial-last-dialed-number.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -185,6 +186,8 @@ This package provides default configs for bluez
 %patch15 -p1
 # AVDTP-stream-abort-handling.patch
 %patch16 -p1
+# HFP-memory-dial-last-dialed-number.patch
+%patch17 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
Use the last dialed number as memory dialing location one; respond with an error to attempts to memory dial any other location.
