### PR TITLE
[bluez] Tweak local name queries. Fixes JB#11905.

### DIFF
--- a/rpm/bluetoothd-local-name-fix.patch
+++ b/rpm/bluetoothd-local-name-fix.patch
@@ -1,0 +1,40 @@
+diff -Naur bluez.orig/plugins/hciops.c bluez/plugins/hciops.c
+--- bluez.orig/plugins/hciops.c	2013-10-30 09:33:52.481785668 +0000
++++ bluez/plugins/hciops.c	2013-10-30 12:44:35.422210692 +0000
+@@ -1623,6 +1623,22 @@
+ 	update_ext_inquiry_response(index);
+ }
+ 
++static gboolean read_local_name_cb(gpointer data)
++{
++	int index = GPOINTER_TO_INT(data);
++	struct dev_info *dev = &devs[index];
++
++	DBG("hci%d checking local name pending status", index);
++
++	if (hci_test_bit(PENDING_NAME, &dev->pending)) {
++		DBG("Local name read still pending, forcing. ");
++		hci_send_cmd(dev->sk, OGF_HOST_CTL,
++					OCF_READ_LOCAL_NAME, 0, 0);
++	}
++
++	return FALSE;
++}
++
+ static void read_local_name_complete(int index, read_local_name_rp *rp)
+ {
+ 	struct dev_info *dev = &devs[index];
+@@ -2769,9 +2785,10 @@
+ 		hci_send_cmd(dev->sk, OGF_INFO_PARAM,
+ 					OCF_READ_LOCAL_VERSION, 0, NULL);
+ 
+-	if (hci_test_bit(PENDING_NAME, &dev->pending))
+-		hci_send_cmd(dev->sk, OGF_HOST_CTL,
+-					OCF_READ_LOCAL_NAME, 0, 0);
++	if (hci_test_bit(PENDING_NAME, &dev->pending)) {
++		DBG("Pending local name query");
++		g_timeout_add(3000, read_local_name_cb, GINT_TO_POINTER(index));
++	}
+ 
+ 	if (hci_test_bit(PENDING_BDADDR, &dev->pending))
+ 		hci_send_cmd(dev->sk, OGF_INFO_PARAM,

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -37,6 +37,7 @@ Patch16:    AVDTP-stream-abort-handling.patch
 Patch17:    HFP-memory-dial-last-dialed-number.patch
 Patch18:    telephony-no-sporadic-hold-indicators.patch
 Patch19:    telephony-release-and-answer-workaround.patch
+Patch20:    bluetoothd-local-name-fix.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -194,6 +195,8 @@ This package provides default configs for bluez
 %patch18 -p1
 # telephony-release-and-answer-workaround.patch
 %patch19 -p1
+# bluetoothd-local-name-fix.patch
+%patch20 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
Having an explicit query for local name when the kernel announces
the name to bluetoothd just as well results in two read local name
query complete events with an empty string for name on adapter
powerup. This may cause D-Bus events for adapter name property
change with the name as empty string.

Such property changes may confuse other modules that act based on
the name property; as our kernel seems to reliable send the local
name without bluetoothd explicitly querying it, fix the issue by
deferring local name query until later. By that time it's probably
been received already from the kernel spontaneously and it's not
necessary to make a query.
