### PR TITLE
[bluez] Delay dial after hold. Fixes JB#11613.

### DIFF
--- a/rpm/telephony-hold-and-dial.patch
+++ b/rpm/telephony-hold-and-dial.patch
@@ -1,16 +1,21 @@
 diff -Naur bluez.orig/audio/telephony-ofono.c bluez/audio/telephony-ofono.c
---- bluez.orig/audio/telephony-ofono.c	2013-11-05 15:46:19.221900426 +0800
-+++ bluez/audio/telephony-ofono.c	2013-11-05 16:59:42.747152944 +0800
-@@ -56,6 +56,8 @@
+--- bluez.orig/audio/telephony-ofono.c	2013-11-06 19:20:39.015656997 +0800
++++ bluez/audio/telephony-ofono.c	2013-11-06 19:30:48.947632828 +0800
+@@ -56,6 +56,13 @@
  
  	gboolean status_pending;
  	gboolean waiting_for_answer;
 +	gchar *hold_dial_clir;
 +	gchar *hold_dial_number;
++};
++
++struct dial {
++	gchar *hold_dial_clir;
++	gchar *hold_dial_number;
  };
  
  static DBusConnection *connection = NULL;
-@@ -511,6 +513,7 @@
+@@ -511,6 +518,7 @@
  
  void telephony_dial_number_req(void *telephony_device, const char *number)
  {
@@ -18,7 +23,7 @@ diff -Naur bluez.orig/audio/telephony-ofono.c bluez/audio/telephony-ofono.c
  	const char *clir;
  	int ret;
  
-@@ -553,6 +556,22 @@
+@@ -553,6 +561,22 @@
  	} else
  		clir = "default";
  
@@ -41,7 +46,7 @@ diff -Naur bluez.orig/audio/telephony-ofono.c bluez/audio/telephony-ofono.c
  	ret = send_method_call(OFONO_BUS_NAME, modem_obj_path,
  			OFONO_VCMANAGER_INTERFACE,
                          "Dial", NULL, NULL,
-@@ -863,6 +882,8 @@
+@@ -863,6 +887,8 @@
  	g_dbus_remove_watch(connection, vc->watch);
  	g_free(vc->obj_path);
  	g_free(vc->number);
@@ -50,24 +55,42 @@ diff -Naur bluez.orig/audio/telephony-ofono.c bluez/audio/telephony-ofono.c
  	memset(vc, 0, sizeof(struct voice_call));
  	g_free(vc);
  }
-@@ -969,6 +990,21 @@
+@@ -912,6 +938,22 @@
+ 	}
+ }
+ 
++static gboolean dial_after_hold(gpointer data)
++{
++	struct dial *d = (struct dial *)data;
++	send_method_call(OFONO_BUS_NAME, modem_obj_path,
++			OFONO_VCMANAGER_INTERFACE,
++			"Dial", NULL, NULL,
++			DBUS_TYPE_STRING, &d->hold_dial_number,
++			DBUS_TYPE_STRING, &d->hold_dial_clir,
++			DBUS_TYPE_INVALID);
++	g_free(d->hold_dial_clir);
++	g_free(d->hold_dial_number);
++	g_free(d);
++
++	return FALSE;
++}
++
+ static gboolean handle_vc_property_changed(DBusConnection *conn,
+ 					DBusMessage *msg, void *data)
+ {
+@@ -969,6 +1011,16 @@
  			vc->originating = FALSE;
  		} else if (g_str_equal(state, "held")) {
  			vc->status = CALL_STATUS_HELD;
 +			/* in case we have pending dial, do it now */
 +			if (vc->hold_dial_number != NULL) {
-+				gchar *clir = vc->hold_dial_clir;
-+				gchar *number = vc->hold_dial_number;
++				struct dial *d = NULL;
++				d = g_new0(struct dial, 1);
++				d->hold_dial_clir = vc->hold_dial_clir;
++				d->hold_dial_number = vc->hold_dial_number;
 +				vc->hold_dial_clir = NULL;
 +				vc->hold_dial_number = NULL;
-+				send_method_call(OFONO_BUS_NAME, modem_obj_path,
-+						OFONO_VCMANAGER_INTERFACE,
-+						"Dial", NULL, NULL,
-+						DBUS_TYPE_STRING, &number,
-+						DBUS_TYPE_STRING, &clir,
-+						DBUS_TYPE_INVALID);
-+				g_free(clir);
-+				g_free(number);
++				g_timeout_add_seconds(1, dial_after_hold, d);
 +			}
  		}
  		update_held_status();


### PR DESCRIPTION
As we're not getting ofono result codes, have to delay dialing
after primary call is put on hold; otherwise ofono may fail
the dial attempt with "InProgress" code.
