### PR TITLE
[bluez] Fix bluetoothd startup dbus crash. Fixes JB#11740

### DIFF
--- a/rpm/bluetoothd-startup-dbus-crash-fix.patch
+++ b/rpm/bluetoothd-startup-dbus-crash-fix.patch
@@ -1,0 +1,40 @@
+diff -Naur bluez.orig/gdbus/watch.c bluez/gdbus/watch.c
+--- bluez.orig/gdbus/watch.c	2013-10-29 07:24:48.891641000 +0000
++++ bluez/gdbus/watch.c	2013-11-15 02:02:51.000000000 +0000
+@@ -42,6 +42,10 @@
+ 
+ static guint listener_id = 0;
+ static GSList *listeners = NULL;
++/*Add this flag to avoid call dbus_connection_remove_filter() twice*/
++static gboolean msg_filter_need_free = FALSE;
++
++
+ 
+ struct service_data {
+ 	DBusConnection *conn;
+@@ -205,9 +209,11 @@
+ 	const char *name = NULL, *owner = NULL;
+ 
+ 	if (filter_data_find(connection, NULL, NULL, NULL, NULL, NULL, NULL) == NULL) {
++		msg_filter_need_free = TRUE;
+ 		if (!dbus_connection_add_filter(connection,
+ 					message_filter, NULL, NULL)) {
+ 			error("dbus_connection_add_filter() failed");
++			msg_filter_need_free = FALSE;
+ 			return NULL;
+ 		}
+ 	}
+@@ -381,10 +387,11 @@
+ 	/* Remove filter if there are no listeners left for the connection */
+ 	data = filter_data_find(connection, NULL, NULL, NULL, NULL, NULL,
+ 					NULL);
+-	if (data == NULL)
++	if ((data == NULL) && msg_filter_need_free) {
++		msg_filter_need_free = FALSE;
+ 		dbus_connection_remove_filter(connection, message_filter,
+ 						NULL);
+-
++	}
+ 	dbus_connection_unref(connection);
+ 
+ 	return TRUE;

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -40,6 +40,7 @@ Patch19:    telephony-release-and-answer-workaround.patch
 Patch20:    bluetoothd-local-name-fix.patch
 Patch21:    telephony-no-sporadic-call-status-indicators.patch
 Patch22:    telephony-hold-and-dial.patch
+Patch23:    bluetoothd-startup-dbus-crash-fix.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -203,6 +204,8 @@ This package provides default configs for bluez
 %patch21 -p1
 # telephony-hold-and-dial.patch
 %patch22 -p1
+# bluetoothd-startup-dbus-crash-fix.patch
+%patch23 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
When phone startup with bluetooth disabled, some times because of
the rfkill initialize sequence, the hci will up then down quickly.
In this case, the dbus_connection_remove_filter() will be called
twice because of the nested call of
filter_data_free() and filter_data_remove_callback().
Add a flag to make sure dbus_connection_remove_filter() won't be
called twice.
