### PR TITLE
[bluez] Fix crash when connect to BT keyboard. Fixes JB#13213

### DIFF
--- a/rpm/bluetoothd-connect-BT-keyboard-crash-fix.patch
+++ b/rpm/bluetoothd-connect-BT-keyboard-crash-fix.patch
@@ -1,0 +1,17 @@
+diff -Naur bluez.orig/lib/hci.h bluez/lib/hci.h
+--- bluez.orig/lib/hci.h	2013-12-13 14:51:27.254925000 +0800
++++ bluez/lib/hci.h	2013-12-13 16:19:52.000000000 +0800
+@@ -2346,6 +2346,13 @@
+ 	uint8_t	 out;
+ 	uint16_t state;
+ 	uint32_t link_mode;
++	
++	/*Add below member due to Qcomm linux kernel change*/
++	uint32_t    mtu;
++	uint32_t    cnt;
++	uint32_t    pkts;
++	uint8_t     pending_sec_level;
++	uint8_t     ssp_mode;
+ };
+ 
+ struct hci_dev_req {

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -42,6 +42,7 @@ Patch21:    telephony-no-sporadic-call-status-indicators.patch
 Patch22:    telephony-hold-and-dial.patch
 Patch23:    bluetoothd-startup-dbus-crash-fix.patch
 Patch24:    AVDTP-fix-crash-after-disconnecting.patch
+Patch25:    bluetoothd-connect-BT-keyboard-crash-fix.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -209,6 +210,8 @@ This package provides default configs for bluez
 %patch23 -p1
 # AVDTP-fix-crash-after-disconnecting.patch
 %patch24 -p2
+# bluetoothd-connect-BT-keyboard-crash-fix.patch
+%patch25 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
hciops_encrypt_link() will be called when connect to BT keyboard.
In this function, "struct hci_conn_info" is used by
ioctl(dd, HCIGETCONNINFO, cr) to get information from linux kernel.
But Qcomm's kernel changed "struct hci_conn_info"'s definition,
thus caused this memory related crash.
