### PR TITLE
[bluez] Initialize uinput file descriptor. Fixes JB#14112.

### DIFF
--- a/rpm/AVCTP-initialize-uinput-fd.patch
+++ b/rpm/AVCTP-initialize-uinput-fd.patch
@@ -1,0 +1,11 @@
+diff -Naur bluez.orig/audio/avctp.c bluez/audio/avctp.c
+--- bluez.orig/audio/avctp.c	2013-12-17 12:16:32.020737057 +0200
++++ bluez/audio/avctp.c	2013-12-17 12:17:17.676735404 +0200
+@@ -722,6 +722,7 @@
+ 	session->server = server;
+ 	bacpy(&session->dst, dst);
+ 	session->state = AVCTP_STATE_DISCONNECTED;
++	session->uinput = -1;
+ 
+ 	server->sessions = g_slist_append(server->sessions, session);
+ 

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -42,6 +42,7 @@ Patch21:    telephony-no-sporadic-call-status-indicators.patch
 Patch22:    telephony-hold-and-dial.patch
 Patch23:    bluetoothd-startup-dbus-crash-fix.patch
 Patch24:    AVDTP-fix-crash-after-disconnecting.patch
+Patch25:    AVCTP-initialize-uinput-fd.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -209,6 +210,8 @@ This package provides default configs for bluez
 %patch23 -p1
 # AVDTP-fix-crash-after-disconnecting.patch
 %patch24 -p2
+# AVCTP-initialize-uinput-fd.patch
+%patch25 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
Having session->uinput as zero after allocation causes unintended fd 0 closing, trivial to fix.
