### PR TITLE
[bluez] Update HFP feature advertisment. Fixes JB#14241.

### DIFF
--- a/rpm/HFP-feature-advertisment.patch
+++ b/rpm/HFP-feature-advertisment.patch
@@ -1,0 +1,53 @@
+diff -Naur bluez.orig/audio/headset.c bluez/audio/headset.c
+--- bluez.orig/audio/headset.c	2014-01-13 09:32:13.505725843 +0200
++++ bluez/audio/headset.c	2014-01-13 10:05:17.625654029 +0200
+@@ -2910,6 +2910,8 @@
+ 
+ 	print_ag_features(ag.features);
+ 
++	manager_update_hfp_ag_record(ag.features);
++
+ 	return 0;
+ }
+ 
+diff -Naur bluez.orig/audio/manager.c bluez/audio/manager.c
+--- bluez.orig/audio/manager.c	2014-01-13 09:32:13.505725843 +0200
++++ bluez/audio/manager.c	2014-01-13 11:12:36.194147010 +0200
+@@ -1560,3 +1560,28 @@
+ 				adapter_get_dev_id(adapter->btd_adapter));
+ 	}
+ }
++
++void manager_update_hfp_ag_record(uint32_t feat)
++{
++	GSList *l;
++
++	for (l = adapters; l; l = l->next) {
++		uint16_t sdpfeat;
++		sdp_data_t *features = NULL;
++		sdp_record_t *record = NULL;
++		struct audio_adapter *adapter = l->data;
++
++		if (!adapter->hfp_ag_record_id) {
++			continue;
++		}
++
++		record = sdp_record_find(adapter->hfp_ag_record_id);
++		if (record == NULL) {
++			continue;
++		}
++
++		sdpfeat = (uint16_t) feat & 0x1F;
++		features = sdp_data_alloc(SDP_UINT16, &sdpfeat);
++		sdp_attr_replace(record, SDP_ATTR_SUPPORTED_FEATURES, features);
++	}
++}
+diff -Naur bluez.orig/audio/manager.h bluez/audio/manager.h
+--- bluez.orig/audio/manager.h	2014-01-13 09:32:13.505725843 +0200
++++ bluez/audio/manager.h	2014-01-13 10:05:24.377653785 +0200
+@@ -61,3 +61,5 @@
+ /* TRUE to enable fast connectable and FALSE to disable fast connectable for all
+  * audio adapters. */
+ void manager_set_fast_connectable(gboolean enable);
++
++void manager_update_hfp_ag_record(uint32_t features);

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -43,6 +43,7 @@ Patch22:    telephony-hold-and-dial.patch
 Patch23:    bluetoothd-startup-dbus-crash-fix.patch
 Patch24:    AVDTP-fix-crash-after-disconnecting.patch
 Patch25:    AVCTP-initialize-uinput-fd.patch
+Patch26:    HFP-feature-advertisment.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -212,6 +213,8 @@ This package provides default configs for bluez
 %patch24 -p2
 # AVCTP-initialize-uinput-fd.patch
 %patch25 -p1
+# HFP-feature-advertisment.patch
+%patch26 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
bluetoothd did not update feature bitmask in service record
after telephony plugin had been initialized, which caused
interoperability problems with some headsets. Bitmask
update after telephony_ready_ind() gets called added.
