### PR TITLE
Reconnect when boths sides tried to connect. Fixes JB#13887.

### DIFF
--- a/rpm/AVCTP-handle-simultaneous-connections.patch
+++ b/rpm/AVCTP-handle-simultaneous-connections.patch
@@ -1,0 +1,67 @@
+diff -Naur bluez.orig/audio/avctp.c bluez/audio/avctp.c
+--- bluez.orig/audio/avctp.c	2014-01-13 15:08:57.901989974 +0200
++++ bluez/audio/avctp.c	2014-01-13 16:04:44.913868830 +0200
+@@ -68,6 +68,8 @@
+ #define AVCTP_PACKET_CONTINUE	2
+ #define AVCTP_PACKET_END	3
+ 
++#define MAX_CONN_RETRIES 4
++
+ #if __BYTE_ORDER == __LITTLE_ENDIAN
+ 
+ struct avctp_header {
+@@ -143,6 +145,9 @@
+ 
+ 	uint8_t key_quirks[256];
+ 	GSList *handlers;
++
++	guint retries;
++	gboolean incoming_dropped;
+ };
+ 
+ struct avctp_pdu_handler {
+@@ -620,6 +625,33 @@
+ 	GError *gerr = NULL;
+ 
+ 	if (err) {
++		if (session->incoming_dropped &&
++			session->retries < MAX_CONN_RETRIES) {
++			/* Simultaneous connection attempts failed on
++			   both sides; cleanup and retry with the same
++			   callback. */
++			GError *retry_err = NULL;
++			GIOChannel *io = NULL;
++
++			g_io_channel_shutdown(session->io, TRUE, NULL);
++			g_io_channel_unref(session->io);
++			session->io = NULL;
++			session->incoming_dropped = FALSE;
++			session->retries++;
++
++			io = bt_io_connect(BT_IO_L2CAP, avctp_connect_cb,
++					session, NULL, NULL,
++					BT_IO_OPT_SOURCE_BDADDR,
++					&session->server->src,
++					BT_IO_OPT_DEST_BDADDR, &session->dst,
++					BT_IO_OPT_PSM, AVCTP_PSM,
++					BT_IO_OPT_INVALID);
++			if (io != NULL) {
++				session->io = io;
++				return;
++			}
++		}
++
+ 		avctp_set_state(session, AVCTP_STATE_DISCONNECTED);
+ 		error("%s", err->message);
+ 		return;
+@@ -773,7 +805,9 @@
+ 
+ 	if (session->io) {
+ 		error("Refusing unexpected connect from %s", address);
+-		goto drop;
++		session->incoming_dropped = TRUE;
++		g_io_channel_shutdown(chan, TRUE, NULL);
++		return;
+ 	}
+ 
+ 	avctp_set_state(session, AVCTP_STATE_CONNECTING);

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -45,6 +45,7 @@ Patch24:    AVDTP-fix-crash-after-disconnecting.patch
 Patch25:    AVCTP-initialize-uinput-fd.patch
 Patch26:    HFP-feature-advertisment.patch
 Patch27:    bluetoothd-connect-BT-keyboard-crash-fix.patch
+Patch28:    AVCTP-handle-simultaneous-connections.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -218,6 +219,8 @@ This package provides default configs for bluez
 %patch26 -p1
 # bluetoothd-connect-BT-keyboard-crash-fix.patch
 %patch27 -p1
+# AVCTP-handle-simultaneous-connections.patch
+%patch28 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
In case an incoming connection was dropped when AVCTP connection
attempt was ongoing and the attempt failed, retry the connection
a few times. Otherwise no AVCTP connection might be formed at all;
there are headsets which disallow incoming connections when they
are connecting themselves, but won't retry after a failure.
