### PR TITLE
[bluez] Start AVDTP after delay even if not INT. Contributes to JB#10965...

### DIFF
--- a/rpm/AVDTP-start-after-timeout.patch
+++ b/rpm/AVDTP-start-after-timeout.patch
@@ -1,0 +1,132 @@
+diff -Naur bluez.orig/audio/avdtp.c bluez/audio/avdtp.c
+--- bluez.orig/audio/avdtp.c	2013-12-18 13:38:09.278658229 +0200
++++ bluez/audio/avdtp.c	2013-12-18 14:40:50.430522096 +0200
+@@ -92,7 +92,7 @@
+ #define REQ_TIMEOUT 6
+ #define ABORT_TIMEOUT 2
+ #define DISCONNECT_TIMEOUT 1
+-#define STREAM_TIMEOUT 20
++#define START_TIMEOUT 1
+ 
+ #if __BYTE_ORDER == __LITTLE_ENDIAN
+ 
+@@ -376,7 +376,7 @@
+ 	gboolean open_acp;	/* If we are in ACT role for Open */
+ 	gboolean close_int;	/* If we are in INT role for Close */
+ 	gboolean abort_int;	/* If we are in INT role for Abort */
+-	guint idle_timer;
++	guint start_timer;	/* Wait START command timer */
+ 	gboolean delay_reporting;
+ 	uint16_t delay;		/* AVDTP 1.3 Delay Reporting feature */
+ 	gboolean starting;	/* only valid while sep state == OPEN */
+@@ -794,6 +794,9 @@
+ 	if (stream->timer)
+ 		g_source_remove(stream->timer);
+ 
++	if (stream->start_timer)
++		g_source_remove(stream->start_timer);
++
+ 	if (stream->io)
+ 		close_stream(stream);
+ 
+@@ -806,19 +809,6 @@
+ 	g_free(stream);
+ }
+ 
+-static gboolean stream_timeout(gpointer user_data)
+-{
+-	struct avdtp_stream *stream = user_data;
+-	struct avdtp *session = stream->session;
+-
+-	if (avdtp_close(session, stream, FALSE) < 0)
+-		error("stream_timeout: closing AVDTP stream failed");
+-
+-	stream->idle_timer = 0;
+-
+-	return FALSE;
+-}
+-
+ static gboolean transport_cb(GIOChannel *chan, GIOCondition cond,
+ 				gpointer data)
+ {
+@@ -1069,30 +1059,25 @@
+ 		break;
+ 	case AVDTP_STATE_OPEN:
+ 		stream->starting = FALSE;
+-		if ((old_state > AVDTP_STATE_OPEN && session->auto_dc) ||
+-							stream->open_acp)
+-			stream->idle_timer = g_timeout_add_seconds(STREAM_TIMEOUT,
+-								stream_timeout,
+-								stream);
+ 		break;
+ 	case AVDTP_STATE_STREAMING:
+-		if (stream->idle_timer) {
+-			g_source_remove(stream->idle_timer);
+-			stream->idle_timer = 0;
++		if (stream->start_timer) {
++			g_source_remove(stream->start_timer);
++			stream->start_timer = 0;
+ 		}
+ 		stream->open_acp = FALSE;
+ 		break;
+ 	case AVDTP_STATE_CLOSING:
+ 	case AVDTP_STATE_ABORTING:
+-		if (stream->idle_timer) {
+-			g_source_remove(stream->idle_timer);
+-			stream->idle_timer = 0;
++		if (stream->start_timer) {
++			g_source_remove(stream->start_timer);
++			stream->start_timer = 0;
+ 		}
+ 		break;
+ 	case AVDTP_STATE_IDLE:
+-		if (stream->idle_timer) {
+-			g_source_remove(stream->idle_timer);
+-			stream->idle_timer = 0;
++		if (stream->start_timer) {
++			g_source_remove(stream->start_timer);
++			stream->start_timer = 0;
+ 		}
+ 		if (session->pending_open == stream)
+ 			handle_transport_connect(session, NULL, 0, 0);
+@@ -3664,6 +3649,23 @@
+ 							&req, sizeof(req));
+ }
+ 
++static gboolean start_timeout(gpointer user_data)
++{
++	struct avdtp_stream *stream = user_data;
++	struct avdtp *session = stream->session;
++
++	DBG("");
++
++	stream->open_acp = FALSE;
++
++	if (avdtp_start(session, stream) < 0)
++		error("wait_timeout: avdtp_start failed");
++
++	stream->start_timer = 0;
++
++	return FALSE;
++}
++
+ int avdtp_start(struct avdtp *session, struct avdtp_stream *stream)
+ {
+ 	struct start_req req;
+@@ -3680,7 +3682,15 @@
+ 	 *  to start the streaming via GAVDP_START.
+ 	 */
+ 	if (stream->open_acp) {
+-		stream->starting = TRUE;
++		/* If timer already active wait it */
++		if (stream->start_timer)
++			return 0;
++
++		DBG("Start timeout pending.");
++
++		stream->start_timer = g_timeout_add_seconds(START_TIMEOUT,
++								start_timeout,
++								stream);
+ 		return 0;
+ 	}
+ 

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -46,6 +46,7 @@ Patch25:    AVCTP-initialize-uinput-fd.patch
 Patch26:    HFP-feature-advertisment.patch
 Patch27:    bluetoothd-connect-BT-keyboard-crash-fix.patch
 Patch28:    AVCTP-handle-simultaneous-connections.patch
+Patch29:    AVDTP-start-after-timeout.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -221,6 +222,8 @@ This package provides default configs for bluez
 %patch27 -p1
 # AVCTP-handle-simultaneous-connections.patch
 %patch28 -p1
+# AVDTP-start-after-timeout.patch
+%patch29 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
....

bluetoothd would not issue a AVDTP stream start if it was not the
initiator; however Sony SBH50 headset would also not issue AVDTP
stream start even if it is and had configured the stream, so no
audio would flow.

Applied upstream commit e2d49cfa8 with some small additions.
