### PR TITLE
[bluetooth] Handle AVCTP invalid PID properly. Fixes JB#16270.

### DIFF
--- a/rpm/AVCTP-invalid-pid-response.patch
+++ b/rpm/AVCTP-invalid-pid-response.patch
@@ -1,0 +1,12 @@
+diff -Naur bluez.orig/audio/avctp.c bluez/audio/avctp.c
+--- bluez.orig/audio/avctp.c	2014-02-20 15:07:02.601940253 +0200
++++ bluez/audio/avctp.c	2014-02-20 15:11:56.645952795 +0200
+@@ -504,7 +504,7 @@
+ 
+ 	if (avctp->pid != htons(AV_REMOTE_SVCLASS_ID)) {
+ 		avctp->ipid = 1;
+-		avc->code = AVC_CTYPE_REJECTED;
++		packet_size = AVCTP_HEADER_LENGTH;
+ 		goto done;
+ 	}
+ 

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -46,6 +46,7 @@ Patch26:    HFP-feature-advertisment.patch
 Patch27:    bluetoothd-connect-BT-keyboard-crash-fix.patch
 Patch28:    AVCTP-handle-simultaneous-connections.patch
 Patch29:    AVDTP-start-after-timeout.patch
+Patch30:    AVCTP-invalid-pid-response.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -223,6 +224,8 @@ This package provides default configs for bluez
 %patch28 -p1
 # AVDTP-start-after-timeout.patch
 %patch29 -p1
+# AVCTP-invalid-pid-response.patch
+%patch30 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
Per spec the response to a command with invalid PID must contain only the AVCTP header.
