### PR TITLE
[bluez] HID connection special case handling. Fixes JB#16819, JB#16866

### DIFF
--- a/rpm/HID-auto-reconnect.patch
+++ b/rpm/HID-auto-reconnect.patch
@@ -1,0 +1,879 @@
+diff -Naur bluez.orig/input/device.c bluez/input/device.c
+--- bluez.orig/input/device.c	2014-03-06 15:48:12.493426320 +0200
++++ bluez/input/device.c	2014-03-11 10:53:52.519284693 +0200
+@@ -67,6 +67,20 @@
+ 
+ #define FI_FLAG_CONNECTED	1
+ 
++enum reconnect_mode_t {
++	RECONNECT_NONE = 0,
++	RECONNECT_DEVICE,
++	RECONNECT_HOST,
++	RECONNECT_ANY
++};
++
++static const char * const _reconnect_mode_str[] = {
++	"none",
++	"device",
++	"host",
++	"any"
++};
++
+ struct input_conn {
+ 	struct fake_input	*fake;
+ 	DBusMessage		*pending_connect;
+@@ -92,10 +106,22 @@
+ 	char			*name;
+ 	struct btd_device	*device;
+ 	GSList			*connections;
++	enum reconnect_mode_t   reconnect_mode;
++	guint			reconnect_timer;
++	uint32_t		reconnect_attempt;
++	gboolean                temp;
+ };
+ 
+ static GSList *devices = NULL;
+ 
++static void input_device_enter_reconnect_mode(struct input_device *idev);
++static const char *reconnect_mode_to_string(const enum reconnect_mode_t mode);
++
++static const char *reconnect_mode_to_string(const enum reconnect_mode_t mode)
++{
++	return _reconnect_mode_str[mode];
++}
++
+ static struct input_device *find_device_by_path(GSList *list, const char *path)
+ {
+ 	for (; list; list = list->next) {
+@@ -150,6 +176,9 @@
+ 	if (idev->dc_id)
+ 		device_remove_disconnect_watch(idev->device, idev->dc_id);
+ 
++	if (idev->reconnect_timer > 0)
++		g_source_remove(idev->reconnect_timer);
++
+ 	dbus_connection_unref(idev->conn);
+ 	btd_device_unref(idev->device);
+ 	g_free(idev->name);
+@@ -388,6 +417,8 @@
+ 	struct input_device *idev = iconn->idev;
+ 	gboolean connected = FALSE;
+ 
++	DBG("");
++
+ 	/* Checking for ctrl_watch avoids a double g_io_channel_shutdown since
+ 	 * it's likely that ctrl_watch_cb has been queued for dispatching in
+ 	 * this mainloop iteration */
+@@ -409,6 +440,9 @@
+ 	if (iconn->ctrl_io && !(cond & G_IO_NVAL))
+ 		g_io_channel_shutdown(iconn->ctrl_io, TRUE, NULL);
+ 
++	/* Enter the auto-reconnect mode if needed */
++	input_device_enter_reconnect_mode(idev);
++
+ 	return FALSE;
+ }
+ 
+@@ -416,6 +450,8 @@
+ {
+ 	struct input_conn *iconn = data;
+ 
++	DBG("");
++
+ 	/* Checking for intr_watch avoids a double g_io_channel_shutdown since
+ 	 * it's likely that intr_watch_cb has been queued for dispatching in
+ 	 * this mainloop iteration */
+@@ -438,6 +474,8 @@
+ {
+ 	struct fake_hid *fhid = iconn->fake->priv;
+ 
++	DBG("");
++
+ 	return fhid->connect(iconn->fake, err);
+ }
+ 
+@@ -445,6 +483,8 @@
+ {
+ 	struct fake_hid *fhid = iconn->fake->priv;
+ 
++	DBG("");
++
+ 	return fhid->disconnect(iconn->fake);
+ }
+ 
+@@ -473,6 +513,39 @@
+ 	}
+ }
+ 
++static enum reconnect_mode_t hid_reconnection_mode(gboolean reconnect_initiate,
++						gboolean normally_connectable)
++{
++	if (!reconnect_initiate && !normally_connectable)
++		return RECONNECT_NONE;
++	else if (!reconnect_initiate && normally_connectable)
++		return RECONNECT_HOST;
++	else if (reconnect_initiate && !normally_connectable)
++		return RECONNECT_DEVICE;
++	else /* (reconnect_initiate && normally_connectable) */
++		return RECONNECT_ANY;
++}
++
++static void extract_hid_props(struct input_device *idev,
++			const sdp_record_t *rec)
++{
++	/* Extract HID connectability */
++	gboolean reconnect_initiate, normally_connectable;
++	sdp_data_t *pdlist;
++
++	/* HIDNormallyConnectable is optional and assumed FALSE
++	 * if not present. */
++	pdlist = sdp_data_get(rec, SDP_ATTR_HID_RECONNECT_INITIATE);
++	reconnect_initiate = pdlist ? pdlist->val.uint8 : TRUE;
++	
++	pdlist = sdp_data_get(rec, SDP_ATTR_HID_NORMALLY_CONNECTABLE);
++	normally_connectable = pdlist ? pdlist->val.uint8 : FALSE;
++	
++	/* Update local values */
++	idev->reconnect_mode =
++		hid_reconnection_mode(reconnect_initiate, normally_connectable);
++}
++
+ static void extract_hid_record(sdp_record_t *rec, struct hidp_connadd_req *req)
+ {
+ 	sdp_data_t *pdlist, *pdlist2;
+@@ -534,6 +607,8 @@
+ {
+ 	int ctl, err = 0;
+ 
++	DBG("");
++
+ 	ctl = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HIDP);
+ 	if (ctl < 0)
+ 		return -errno;
+@@ -551,6 +626,8 @@
+ 	struct hidp_connadd_req *req = user_data;
+ 	int err;
+ 
++	DBG("");
++
+ 	if (status) {
+ 		error("Encryption failed: %s(0x%x)",
+ 				strerror(bt_error(status)), status);
+@@ -588,7 +665,7 @@
+ 	return FALSE;
+ }
+ 
+-static int hidp_add_connection(const struct input_device *idev,
++static int hidp_add_connection(struct input_device *idev,
+ 					struct input_conn *iconn)
+ {
+ 	struct hidp_connadd_req *req;
+@@ -599,6 +676,8 @@
+ 	GError *gerr = NULL;
+ 	int err;
+ 
++	DBG("idev %p", idev);
++
+ 	req = g_new0(struct hidp_connadd_req, 1);
+ 	req->ctrl_sock = g_io_channel_unix_get_fd(iconn->ctrl_io);
+ 	req->intr_sock = g_io_channel_unix_get_fd(iconn->intr_io);
+@@ -616,6 +695,7 @@
+ 	}
+ 
+ 	extract_hid_record(rec, req);
++	extract_hid_props(idev, rec);
+ 	sdp_record_free(rec);
+ 
+ 	req->vendor = btd_device_get_vendor(idev->device);
+@@ -723,6 +803,8 @@
+ 	struct hidp_conninfo ci;
+ 	int ctl, err = 0;
+ 
++	DBG("idev %p", idev);
++
+ 	/* Fake input disconnect */
+ 	if (fake) {
+ 		err = fake->disconnect(iconn);
+@@ -772,6 +854,8 @@
+ 	struct input_conn *iconn = NULL;
+ 	GSList *l;
+ 
++	DBG("idev %p", idev);
++
+ 	for (l = idev->connections; l; l = l->next) {
+ 		iconn = l->data;
+ 
+@@ -804,6 +888,8 @@
+ 	dbus_bool_t connected;
+ 	int err;
+ 
++	DBG("idev %p", idev);
++
+ 	if (iconn->intr_io == NULL || iconn->ctrl_io == NULL)
+ 		return -ENOTCONN;
+ 
+@@ -833,10 +919,12 @@
+ {
+ 	struct input_conn *iconn = user_data;
+ 	struct input_device *idev = iconn->idev;
+-	DBusMessage *reply;
++	DBusMessage *reply = NULL;
+ 	int err;
+ 	const char *err_msg;
+ 
++	DBG("idev %p", idev);
++
+ 	if (conn_err) {
+ 		err_msg = conn_err->message;
+ 		goto failed;
+@@ -849,20 +937,22 @@
+ 	}
+ 
+ 	/* Replying to the requestor */
+-	g_dbus_send_reply(idev->conn, iconn->pending_connect, DBUS_TYPE_INVALID);
+-
+-	dbus_message_unref(iconn->pending_connect);
+-	iconn->pending_connect = NULL;
++	if (iconn->pending_connect) {
++		g_dbus_send_reply(idev->conn, iconn->pending_connect, DBUS_TYPE_INVALID);
++		dbus_message_unref(iconn->pending_connect);
++		iconn->pending_connect = NULL;
++	}
+ 
+ 	return;
+ 
+ failed:
+ 	error("%s", err_msg);
+-	reply = btd_error_failed(iconn->pending_connect, err_msg);
+-	g_dbus_send_message(idev->conn, reply);
+-
+-	dbus_message_unref(iconn->pending_connect);
+-	iconn->pending_connect = NULL;
++	if (iconn->pending_connect) {
++		reply = btd_error_failed(iconn->pending_connect, err_msg);
++		g_dbus_send_message(idev->conn, reply);
++		dbus_message_unref(iconn->pending_connect);
++		iconn->pending_connect = NULL;
++	}
+ 
+ 	/* So we guarantee the interrupt channel is closed before the
+ 	 * control channel (if we only do unref GLib will close it only
+@@ -884,14 +974,17 @@
+ {
+ 	struct input_conn *iconn = user_data;
+ 	struct input_device *idev = iconn->idev;
+-	DBusMessage *reply;
++	DBusMessage *reply = NULL;
+ 	GIOChannel *io;
+ 	GError *err = NULL;
+ 
++	DBG("");
++
+ 	if (conn_err) {
+ 		error("%s", conn_err->message);
+-		reply = btd_error_failed(iconn->pending_connect,
+-						conn_err->message);
++		if (iconn->pending_connect)
++			reply = btd_error_failed(iconn->pending_connect,
++							conn_err->message);
+ 		goto failed;
+ 	}
+ 
+@@ -905,7 +998,8 @@
+ 				BT_IO_OPT_INVALID);
+ 	if (!io) {
+ 		error("%s", err->message);
+-		reply = btd_error_failed(iconn->pending_connect,
++		if (iconn->pending_connect)
++			reply = btd_error_failed(iconn->pending_connect,
+ 							err->message);
+ 		g_error_free(err);
+ 		goto failed;
+@@ -918,15 +1012,20 @@
+ failed:
+ 	g_io_channel_unref(iconn->ctrl_io);
+ 	iconn->ctrl_io = NULL;
+-	g_dbus_send_message(idev->conn, reply);
+-	dbus_message_unref(iconn->pending_connect);
+-	iconn->pending_connect = NULL;
++	if (reply)
++		g_dbus_send_message(idev->conn, reply);
++	if (iconn->pending_connect) {
++		dbus_message_unref(iconn->pending_connect);
++		iconn->pending_connect = NULL;
++	}
+ }
+ 
+ static int fake_disconnect(struct input_conn *iconn)
+ {
+ 	struct fake_input *fake = iconn->fake;
+ 
++	DBG("");
++
+ 	if (!fake->io)
+ 		return -ENOTCONN;
+ 
+@@ -943,34 +1042,19 @@
+ 	return 0;
+ }
+ 
+-/*
+- * Input Device methods
+- */
+-static DBusMessage *input_device_connect(DBusConnection *conn,
+-					DBusMessage *msg, void *data)
++static void dev_connect(struct input_device *idev,
++			struct input_conn *iconn,
++			GError **err)
+ {
+-	struct input_device *idev = data;
+-	struct input_conn *iconn;
+ 	struct fake_input *fake;
+-	DBusMessage *reply;
+-	GError *err = NULL;
+ 
+-	iconn = find_connection(idev->connections, HID_UUID);
+-	if (!iconn)
+-		return btd_error_not_supported(msg);
+-
+-	if (iconn->pending_connect)
+-		return btd_error_in_progress(msg);
+-
+-	if (is_connected(iconn))
+-		return btd_error_already_connected(msg);
++	DBG("");
+ 
+-	iconn->pending_connect = dbus_message_ref(msg);
+ 	fake = iconn->fake;
+ 
+ 	if (fake) {
+ 		/* Fake input device */
+-		if (fake->connect(iconn, &err))
++		if (fake->connect(iconn, err))
+ 			fake->flags |= FI_FLAG_CONNECTED;
+ 	} else {
+ 		/* HID devices */
+@@ -980,7 +1064,7 @@
+ 			bt_clear_cached_session(&idev->src, &idev->dst);
+ 
+ 		io = bt_io_connect(BT_IO_L2CAP, control_connect_cb, iconn,
+-					NULL, &err,
++					NULL, err,
+ 					BT_IO_OPT_SOURCE_BDADDR, &idev->src,
+ 					BT_IO_OPT_DEST_BDADDR, &idev->dst,
+ 					BT_IO_OPT_PSM, L2CAP_PSM_HIDP_CTRL,
+@@ -989,6 +1073,105 @@
+ 		iconn->ctrl_io = io;
+ 	}
+ 
++}
++
++static gboolean input_device_auto_reconnect(gpointer user_data)
++{
++	struct input_device *idev = user_data;
++	struct input_conn *iconn;
++	GError *err = NULL;
++
++	DBG("idev %p", idev);
++
++	DBG("path=%s, attempt=%d", idev->path, idev->reconnect_attempt);
++
++	/* Stop the recurrent reconnection attempts if the device is reconnected
++	 * or is marked for removal. */
++	if (device_is_temporary(idev->device) ||
++					device_is_connected(idev->device))
++		return FALSE;
++
++	/* Only attempt an auto-reconnect for at most 3 minutes (6 * 30s). */
++	if (idev->reconnect_attempt >= 6)
++		return FALSE;
++
++	iconn = find_connection(idev->connections, HID_UUID);
++	if (iconn == NULL)
++		return FALSE;
++
++	if (iconn->ctrl_io)
++		return FALSE;
++
++	if (is_connected(iconn))
++		return FALSE;
++
++	idev->reconnect_attempt++;
++
++	dev_connect(idev, iconn, &err);
++	if (err != NULL) {
++		error("%s", err->message);
++		g_error_free(err);
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
++static void input_device_enter_reconnect_mode(struct input_device *idev)
++{
++	DBG("idev %p", idev);
++
++	DBG("path=%s reconnect_mode=%s", idev->path,
++				reconnect_mode_to_string(idev->reconnect_mode));
++
++	/* Only attempt an auto-reconnect when the device is required to accept
++	 * reconnections from the host. */
++	if (idev->reconnect_mode != RECONNECT_ANY &&
++				idev->reconnect_mode != RECONNECT_HOST)
++		return;
++
++	/* If the device is temporary we are not required to reconnect with the
++	 * device. This is likely the case of a removing device. */
++	if (device_is_temporary(idev->device))
++		return;
++
++	if (idev->reconnect_timer > 0)
++		g_source_remove(idev->reconnect_timer);
++
++	DBG("registering auto-reconnect");
++	idev->reconnect_attempt = 0;
++	idev->reconnect_timer = g_timeout_add_seconds(30,
++					input_device_auto_reconnect, idev);
++
++}
++
++/*
++ * Input Device methods
++ */
++static DBusMessage *input_device_connect(DBusConnection *conn,
++					DBusMessage *msg, void *data)
++{
++	struct input_device *idev = data;
++	struct input_conn *iconn;
++	DBusMessage *reply;
++	GError *err = NULL;
++
++	DBG("idev %p", idev);
++
++	iconn = find_connection(idev->connections, HID_UUID);
++	if (!iconn)
++		return btd_error_not_supported(msg);
++
++	if (iconn->pending_connect)
++		return btd_error_in_progress(msg);
++
++	if (is_connected(iconn))
++		return btd_error_already_connected(msg);
++
++	iconn->pending_connect = dbus_message_ref(msg);
++
++	dev_connect(idev, iconn, &err);
++
+ 	if (err == NULL)
+ 		return NULL;
+ 
+@@ -1006,6 +1189,8 @@
+ 	struct input_device *idev = data;
+ 	int err;
+ 
++	DBG("idev %p", idev);
++
+ 	err = disconnect(idev, 0);
+ 	if (err < 0)
+ 		return btd_error_failed(msg, strerror(-err));
+@@ -1017,6 +1202,8 @@
+ {
+ 	struct input_device *idev = data;
+ 
++	DBG("idev %p", idev);
++
+ 	DBG("Unregistered interface %s on path %s", INPUT_DEVICE_INTERFACE,
+ 								idev->path);
+ 
+@@ -1039,6 +1226,7 @@
+ 	DBusMessageIter iter;
+ 	DBusMessageIter dict;
+ 	dbus_bool_t connected;
++	const char *reconnect_mode = NULL;
+ 
+ 	reply = dbus_message_new_method_return(msg);
+ 	if (!reply)
+@@ -1056,6 +1244,11 @@
+ 					(GCompareFunc) connected_cmp);
+ 	dict_append_entry(&dict, "Connected", DBUS_TYPE_BOOLEAN, &connected);
+ 
++	/* Reconnection mode */
++	reconnect_mode = reconnect_mode_to_string(idev->reconnect_mode);
++	dict_append_entry(&dict, "ReconnectMode", DBUS_TYPE_STRING,
++			&reconnect_mode);
++
+ 	dbus_message_iter_close_container(&iter, &dict);
+ 
+ 	return reply;
+@@ -1086,6 +1279,8 @@
+ 	struct input_device *idev;
+ 	char name[249], src_addr[18], dst_addr[18];
+ 
++	DBG("path %s", path);
++
+ 	idev = g_new0(struct input_device, 1);
+ 	adapter_get_address(adapter, &idev->src);
+ 	device_get_address(device, &idev->dst, NULL);
+@@ -1120,6 +1315,8 @@
+ {
+ 	struct input_conn *iconn;
+ 
++	DBG("idev %p, uuid %s", idev, uuid);
++
+ 	iconn = g_new0(struct input_conn, 1);
+ 	iconn->timeout = timeout;
+ 	iconn->uuid = g_strdup(uuid);
+@@ -1144,6 +1341,8 @@
+ 	struct input_device *idev;
+ 	struct input_conn *iconn;
+ 
++	DBG("path %s, uuid %s", path, uuid);
++
+ 	idev = find_device_by_path(devices, path);
+ 	if (!idev) {
+ 		idev = input_device_new(conn, device, path, rec->handle,
+@@ -1166,6 +1365,8 @@
+ 	struct input_device *idev;
+ 	struct input_conn *iconn;
+ 
++	DBG("path %s, uuid %s", path, uuid);
++
+ 	idev = find_device_by_path(devices, path);
+ 	if (!idev) {
+ 		idev = input_device_new(conn, device, path, 0, FALSE);
+@@ -1205,6 +1406,8 @@
+ 	struct input_device *idev;
+ 	struct input_conn *iconn;
+ 
++	DBG("path %s, uuid %s", path, uuid);
++
+ 	idev = find_device_by_path(devices, path);
+ 	if (idev == NULL)
+ 		return -EINVAL;
+@@ -1233,6 +1436,8 @@
+ {
+ 	int err;
+ 
++	DBG("idev %p", idev);
++
+ 	err = input_device_connected(idev, iconn);
+ 	if (err < 0)
+ 		goto error;
+@@ -1254,11 +1459,45 @@
+ 	return err;
+ }
+ 
++static struct btd_device *device_for_connection(const bdaddr_t *src,
++						const bdaddr_t *dst)
++{
++	struct btd_adapter *adapter;
++	struct btd_device *device;
++	char sstr[18];
++	char dstr[18];
++
++	ba2str(src, sstr);
++	ba2str(dst, dstr);
++
++	adapter = manager_find_adapter(src);
++	if (adapter == NULL) {
++		DBG("No adapter for address %s.", sstr);
++		return NULL;
++	}
++	DBG("Adapter found.");
++
++	device = adapter_find_device(adapter, dstr);
++	if (device == NULL) {
++		DBG("No device for address %s.", dstr);
++		return NULL;
++	}
++
++	return device;
++}
++
+ int input_device_set_channel(const bdaddr_t *src, const bdaddr_t *dst, int psm,
+ 								GIOChannel *io)
+ {
+ 	struct input_device *idev = find_device(src, dst);
+ 	struct input_conn *iconn;
++	char sstr[18], dstr[18];
++
++	ba2str(src, sstr);
++	ba2str(dst, dstr);
++	DBG("src %s, dst %s", sstr, dstr);
++
++	DBG("idev %p", idev);
+ 
+ 	if (!idev)
+ 		return -ENOENT;
+@@ -1290,6 +1529,13 @@
+ {
+ 	struct input_device *idev = find_device(src, dst);
+ 	struct input_conn *iconn;
++	char sstr[18], dstr[18];
++
++	ba2str(src, sstr);
++	ba2str(dst, dstr);
++	DBG("src %s, dst %s", sstr, dstr);
++
++	DBG("idev %p", idev);
+ 
+ 	if (!idev)
+ 		return -ENOENT;
+diff -Naur bluez.orig/input/server.c bluez/input/server.c
+--- bluez.orig/input/server.c	2014-03-06 15:48:12.493426320 +0200
++++ bluez/input/server.c	2014-03-11 11:16:08.639835291 +0200
+@@ -42,13 +42,26 @@
+ #include "adapter.h"
+ #include "device.h"
+ #include "server.h"
++#include "../src/manager.h"
++#include "../src/device.h"
++
++#define MAX_ACCEPT_RETRIES 29
+ 
+ static GSList *servers = NULL;
++
+ struct input_server {
+ 	bdaddr_t src;
+ 	GIOChannel *ctrl;
+ 	GIOChannel *intr;
+ 	GIOChannel *confirm;
++
++	struct {
++		GIOChannel *chan;
++		int retries;
++		bdaddr_t src;
++		bdaddr_t dst;
++		int timer;
++	} pending_accept;
+ };
+ 
+ static gint server_cmp(gconstpointer s, gconstpointer user_data)
+@@ -104,6 +117,140 @@
+ 	g_io_channel_shutdown(chan, TRUE, NULL);
+ }
+ 
++static struct btd_device *device_for_connection(const bdaddr_t *src,
++                                                const bdaddr_t *dst)
++{
++	struct btd_adapter *adapter;
++	struct btd_device *device;
++	char sstr[18];
++	char dstr[18];
++
++	ba2str(src, sstr);
++	ba2str(dst, dstr);
++
++	adapter = manager_find_adapter(src);
++	if (adapter == NULL) {
++		DBG("No adapter for address %s.", sstr);
++		return NULL;
++	}
++	DBG("Adapter found.");
++
++	device = adapter_find_device(adapter, dstr);
++	if (device == NULL) {
++		DBG("No device for address %s.", dstr);
++		return NULL;
++	}
++
++	return device;
++}
++
++static gboolean server_accept(struct input_server *server)
++{
++	GError *err = NULL;
++
++	DBG("");
++
++	if (!bt_io_accept(server->pending_accept.chan, connect_event_cb,
++				server, NULL, &err)) {
++		error("bt_io_accept: %s", err->message);
++		g_error_free(err);
++		return FALSE;
++	}
++
++	return TRUE;
++}
++
++static gboolean retry_server_accept(void *user_data)
++{
++	struct input_server *server = user_data;
++	struct btd_device *device = NULL;
++
++	DBG("");
++
++	device = device_for_connection(&server->pending_accept.src,
++				&server->pending_accept.dst);
++	if (!device) {
++		DBG("No device");
++		goto cleanup;
++	}
++
++	if (device_has_service_records(device)) {
++		DBG("Device has service records");
++		if (!server_accept(server))
++			DBG("Accept failed");
++		goto cleanup;
++	}
++
++	if (server->pending_accept.retries >= MAX_ACCEPT_RETRIES) {
++		DBG("Retry cap reached.");
++		goto cleanup;
++	}
++
++	server->pending_accept.retries++;
++	return TRUE;
++	
++cleanup:
++	server->pending_accept.timer = 0;
++	g_io_channel_unref(server->pending_accept.chan);
++	server->pending_accept.chan = NULL;
++	return FALSE;
++}
++
++static void ctrl_confirm_event_cb(GIOChannel *chan, gpointer user_data)
++{
++	struct input_server *server = user_data;
++	bdaddr_t src, dst;
++	GError *err = NULL;
++	struct btd_device *device = NULL;
++
++	DBG("");
++
++	bt_io_get(chan, BT_IO_L2CAP, &err,
++			BT_IO_OPT_SOURCE_BDADDR, &src,
++			BT_IO_OPT_DEST_BDADDR, &dst,
++			BT_IO_OPT_INVALID);
++	if (err) {
++		error("%s", err->message);
++		g_error_free(err);
++		goto drop;
++	}
++
++	device = device_for_connection(&src, &dst);
++	if (!device) {
++		DBG("No device.");
++		goto drop;
++	}
++
++	if (device_has_service_records(device)) {
++		DBG("Device has service records");
++		server->pending_accept.chan = chan;
++		if (server_accept(server))
++			return;
++
++		DBG("Accept failed");
++		goto drop;
++	}
++
++	if (server->pending_accept.timer) {
++		DBG("Accept already pending.");
++		goto drop;
++	}
++
++	DBG("Device has no service records, pending accept.");
++	server->pending_accept.chan = chan;
++	g_io_channel_ref(server->pending_accept.chan);
++	server->pending_accept.retries = 0;
++	server->pending_accept.src = src;
++	server->pending_accept.dst = dst;
++	server->pending_accept.timer = g_timeout_add_seconds(1,
++							retry_server_accept,
++							server);
++	return;
++
++drop:
++	g_io_channel_shutdown(chan, TRUE, NULL);
++}
++
+ static void auth_callback(DBusError *derr, void *user_data)
+ {
+ 	struct input_server *server = user_data;
+@@ -144,7 +291,7 @@
+ 	input_device_close_channels(&src, &dst);
+ }
+ 
+-static void confirm_event_cb(GIOChannel *chan, gpointer user_data)
++static void intr_confirm_event_cb(GIOChannel *chan, gpointer user_data)
+ {
+ 	struct input_server *server = user_data;
+ 	bdaddr_t src, dst;
+@@ -152,6 +299,8 @@
+ 	char addr[18];
+ 	int ret;
+ 
++	DBG("");
++
+ 	bt_io_get(chan, BT_IO_L2CAP, &err,
+ 			BT_IO_OPT_SOURCE_BDADDR, &src,
+ 			BT_IO_OPT_DEST_BDADDR, &dst,
+@@ -198,7 +347,7 @@
+ 	server = g_new0(struct input_server, 1);
+ 	bacpy(&server->src, src);
+ 
+-	server->ctrl = bt_io_listen(BT_IO_L2CAP, connect_event_cb, NULL,
++	server->ctrl = bt_io_listen(BT_IO_L2CAP, NULL, ctrl_confirm_event_cb,
+ 				server, NULL, &err,
+ 				BT_IO_OPT_SOURCE_BDADDR, src,
+ 				BT_IO_OPT_PSM, L2CAP_PSM_HIDP_CTRL,
+@@ -211,7 +360,7 @@
+ 		return -1;
+ 	}
+ 
+-	server->intr = bt_io_listen(BT_IO_L2CAP, NULL, confirm_event_cb,
++	server->intr = bt_io_listen(BT_IO_L2CAP, NULL, intr_confirm_event_cb,
+ 				server, NULL, &err,
+ 				BT_IO_OPT_SOURCE_BDADDR, src,
+ 				BT_IO_OPT_PSM, L2CAP_PSM_HIDP_INTR,
+@@ -247,6 +396,12 @@
+ 	g_io_channel_shutdown(server->ctrl, TRUE, NULL);
+ 	g_io_channel_unref(server->ctrl);
+ 
++	if (server->pending_accept.timer)
++		g_source_remove(server->pending_accept.timer);
++
++	if (server->pending_accept.chan)
++		g_io_channel_unref(server->pending_accept.chan);
++
+ 	servers = g_slist_remove(servers, server);
+ 	g_free(server);
+ }
+diff -Naur bluez.orig/src/device.c bluez/src/device.c
+--- bluez.orig/src/device.c	2014-03-06 15:48:12.489426320 +0200
++++ bluez/src/device.c	2014-03-11 11:02:34.839864746 +0200
+@@ -2992,6 +2992,22 @@
+ 	services_changed(device);
+ }
+ 
++gboolean device_has_service_records(struct btd_device *device)
++{
++	bdaddr_t src;
++
++	if (device->tmp_records)
++		return TRUE;
++
++	adapter_get_address(device->adapter, &src);
++
++	device->tmp_records = read_records(&src, &device->bdaddr);
++	if (!device->tmp_records)
++		return FALSE;
++
++	return TRUE;
++}
++
+ const sdp_record_t *btd_device_get_record(struct btd_device *device,
+ 							const char *uuid)
+ {
+diff -Naur bluez.orig/src/device.h bluez/src/device.h
+--- bluez.orig/src/device.h	2014-03-06 15:48:12.489426320 +0200
++++ bluez/src/device.h	2014-03-10 14:22:34.992018839 +0200
+@@ -50,6 +50,7 @@
+ int device_browse_sdp(struct btd_device *device, DBusConnection *conn,
+ 			DBusMessage *msg, uuid_t *search, gboolean reverse);
+ void device_probe_drivers(struct btd_device *device, GSList *profiles);
++gboolean device_has_service_records(struct btd_device *device);
+ const sdp_record_t *btd_device_get_record(struct btd_device *device,
+ 						const char *uuid);
+ GSList *btd_device_get_primaries(struct btd_device *device);

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -48,6 +48,7 @@ Patch28:    AVCTP-handle-simultaneous-connections.patch
 Patch29:    AVDTP-start-after-timeout.patch
 Patch30:    AVCTP-invalid-pid-response.patch
 Patch31:    HCI-fix-long-local-name-handling.patch
+Patch32:    HID-auto-reconnect.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -229,6 +230,8 @@ This package provides default configs for bluez
 %patch30 -p1
 # HCI-fix-long-local-name-handling.patch
 %patch31 -p1
+# HID-auto-reconnect.patch
+%patch32 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
- backported two upstream commits:
  
  fb97136ae104ffa8219991bb478d03207723e60a
  5cbdfbd83d663eb98bf81302f9b98d1f7ef4e8f0
  
  to handle automatic reconnection from the host side
  when needed.
- device-initiated connection pends acceptance until
  service discovery is complete. Previously a connection
  attempt from a device for which SDP was not complete
  was rejected
