### PR TITLE
hardcode the droid gid

### DIFF
--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -6,7 +6,7 @@
 Name:       bluez
 
 # >> macros
-%define _system_groupadd() getent group %{1} >/dev/null || groupadd -r %{1}
+%define _system_groupadd() getent group %{1} >/dev/null || groupadd -g 1002 %{1}
 # << macros
 
 Summary:    Bluetooth utilities


### PR DESCRIPTION
If bluez gets installed early in the `mic create` process, bluetooth group is created with the wrong gid.
With sbj this does not happen, because the droid-...-users package is installed first, however with #sailfishforandroid devices, bluez comes first before the droid-hal-... package is able to create required groups.
