### PR TITLE
[bluez] Fix bluez-test dependency. Contributes to JB#17857.

### DIFF
--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -143,7 +143,7 @@ Group:      Development/Tools
 Requires:   %{name} = %{version}-%{release}
 Requires:   bluez-libs = %{version}
 Requires:   dbus-python
-Requires:   pygobject2
+Requires:   pygobject2 >= 3.10.2
 
 %description test
 Scripts for testing BlueZ and its functionality


### PR DESCRIPTION
Require a version of pygobject2 that provides D-Bus
introspection, so that simple-agent and other python
test scripts needing it work.
