### PR TITLE
[bluetooth] Local name handling fixes

### DIFF
--- a/rpm/bluetoothd-cancel-pending-local-name-timeout.patch
+++ b/rpm/bluetoothd-cancel-pending-local-name-timeout.patch
@@ -1,0 +1,113 @@
+diff -Naur bluez.orig/plugins/hciops.c bluez/plugins/hciops.c
+--- bluez.orig/plugins/hciops.c	2014-08-11 10:21:57.905491864 +0300
++++ bluez/plugins/hciops.c	2014-08-11 16:36:43.402347303 +0300
+@@ -174,8 +174,24 @@
+ 
+ 	uint16_t discoverable_timeout;
+ 	guint discoverable_id;
++
++	guint local_name_timeout;
+ } *devs = NULL;
+ 
++static void update_name(int index, const char *name);
++
++static void cancel_local_name_timeout(int index)
++{
++	struct dev_info *dev = &devs[index];
++
++	DBG("hci%d", index);
++
++	if (dev->local_name_timeout) {
++		g_source_remove(dev->local_name_timeout);
++		dev->local_name_timeout = 0;
++	}
++}
++
+ static int found_dev_rssi_cmp(gconstpointer a, gconstpointer b)
+ {
+ 	const struct found_dev *d1 = a, *d2 = b;
+@@ -692,7 +708,7 @@
+ 	struct dev_info *dev = &devs[index];
+ 	change_local_name_cp cp;
+ 
+-	DBG("hci%d, name %s", index, name);
++	DBG("hci%d name '%s'", index, name);
+ 
+ 	memset(&cp, 0, sizeof(cp));
+ 	strncpy((char *) cp.name, name, sizeof(cp.name));
+@@ -783,6 +799,9 @@
+ 		mode = on_mode;
+ 
+ 	if (mode == MODE_OFF) {
++		/* We might have a set local name op pending completion;
++		   force storing a name to the adapter before turning off */
++		update_name(index, dev->name);
+ 		hciops_power_off(index);
+ 		goto done;
+ 	}
+@@ -790,8 +809,10 @@
+ 	start_adapter(index);
+ 
+ 	name = btd_adapter_get_name(adapter);
+-	if (name)
++	if (name) {
++		DBG("hci%d name '%s'", index, name);
+ 		hciops_set_name(index, name);
++	}
+ 
+ 	btd_adapter_get_class(adapter, &major, &minor);
+ 	hciops_set_dev_class(index, major, minor);
+@@ -1617,6 +1638,8 @@
+ {
+ 	struct btd_adapter *adapter;
+ 
++	DBG("hci%d name '%s'", index, name);
++
+ 	adapter = manager_find_adapter_by_id(index);
+ 	if (adapter)
+ 		adapter_name_changed(adapter, name);
+@@ -1649,6 +1672,8 @@
+ 	if (rp->status)
+ 		return;
+ 
++	cancel_local_name_timeout(index);
++
+ 	memcpy(dev->name, rp->name, 248);
+ 	dev->name[248] = '\0';
+ 
+@@ -1659,7 +1684,7 @@
+ 
+ 	hci_clear_bit(PENDING_NAME, &dev->pending);
+ 
+-	DBG("Got name for hci%d", index);
++	DBG("Got name '%s' for hci%d", dev->name, index);
+ 
+ 	if (!dev->pending && dev->up)
+ 		init_adapter(index);
+@@ -2491,6 +2516,8 @@
+ 	g_slist_free_full(dev->uuids, g_free);
+ 	g_slist_free_full(dev->connections, g_free);
+ 
++	cancel_local_name_timeout(index);
++
+ 	init_dev_info(index, -1, dev->registered, dev->already_up);
+ }
+ 
+@@ -2789,7 +2816,8 @@
+ 
+ 	if (hci_test_bit(PENDING_NAME, &dev->pending)) {
+ 		DBG("Pending local name query");
+-		g_timeout_add(3000, read_local_name_cb, GINT_TO_POINTER(index));
++		dev->local_name_timeout = g_timeout_add(3000, read_local_name_cb,
++							GINT_TO_POINTER(index));
+ 	}
+ 
+ 	if (hci_test_bit(PENDING_BDADDR, &dev->pending))
+@@ -2970,6 +2998,7 @@
+ 				btd_adapter_stop(adapter);
+ 
+ 			init_pending(index);
++			cancel_local_name_timeout(index);
+ 		}
+ 		break;
+ 	}

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -51,6 +51,7 @@ Patch31:    HCI-fix-long-local-name-handling.patch
 Patch32:    HID-auto-reconnect.patch
 Patch33:    network-Fix-introspection-of-Connect-method.patch
 Patch34:    bluetoothd-memleak-fixes.patch
+Patch35:    bluetoothd-cancel-pending-local-name-timeout.patch
 Requires:   bluez-libs = %{version}
 Requires:   dbus >= 0.60
 Requires:   hwdata >= 0.215
@@ -238,6 +239,8 @@ This package provides default configs for bluez
 %patch33 -p1
 # bluetoothd-memleak-fixes.patch
 %patch34 -p1
+# bluetoothd-cancel-pending-local-name-timeout.patch
+%patch35 -p1
 # >> setup
 # << setup
 


### PR DESCRIPTION
Fixes related to local name handling.

A previous bugfix introduced a timed out explicit request for
local name, instead of asking it right away; the timeout needs
to be cancelled when local name is received from the controller
before the explicit query is made.

Also, make sure that adapter has a name even if it's to be turned
off before write local name command completes.
