### PR TITLE
[bluez] Do not report a mode change is adapter is already down

### DIFF
--- a/bluez/plugins/hciops.c
+++ b/bluez/plugins/hciops.c
@@ -1858,6 +1858,7 @@ static void set_discoverable_timeout(int index)
 
 static void read_scan_complete(int index, uint8_t status, void *ptr)
 {
+	struct dev_info *dev = &devs[index];
 	struct btd_adapter *adapter;
 	read_scan_enable_rp *rp = ptr;
 
@@ -1871,6 +1872,11 @@ static void read_scan_complete(int index, uint8_t status, void *ptr)
 	default:
 		reset_discoverable_timeout(index);
 		hciops_set_limited_discoverable(index, FALSE);
+	}
+
+	if (!dev->up) {
+		DBG("Device is down, not reporting mode change");
+		return;
 	}
 
 	adapter = manager_find_adapter_by_id(index);


### PR DESCRIPTION
It may happen that hciops receives HCI adapter down event first and a
command complete event for read scan enable command after that;
informing adapter of a mode change after the interface is already down
may result in adapter code getting stuck in off state.

Fixed by not calling adapter_mode_changed() if interface is down.
