### PR TITLE
[bluez] Include held calls in call status indicator

### DIFF
--- a/bluez/audio/telephony-ofono.c
+++ b/bluez/audio/telephony-ofono.c
@@ -927,7 +927,8 @@ static void update_call_status(void)
 		return;
 	}
 
-	if (find_vc_with_status(CALL_STATUS_ACTIVE)) {
+	if (find_vc_with_status(CALL_STATUS_ACTIVE) ||
+			find_vc_with_status(CALL_STATUS_HELD)) {
 		telephony_update_indicator(ofono_indicators,
 					"call",
 					EV_CALL_ACTIVE);


### PR DESCRIPTION
Some carkits get confused by call=0 indicator ofono code sends when an
active call is terminated while there is also a held call present;
They expect the call status indicator to remain at 1 instead.

Strictly speaking HFP 1.5 specifies that call=1 only when there are
active calls, while HFP 1.6 changes the indicator to be 1 when there
are calls in progress (thus having the same meaning as 3GPP 27.007).

In addition, HFP 1.5 figure 4.50 makes no mention of indicating call=0
when releasing an active call while there is a held call present,
which seems to contradict the specification of call status values.

Thus, change code to indicate call=1 also when there are held calls.
