### PR TITLE
add --enable-gatt configuration.

### DIFF
--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -154,7 +154,8 @@ This package provides default configs for bluez
     --enable-hal=no \
     --with-telephony=ofono \
     --with-systemdunitdir=/lib/systemd/system \
-    --enable-jolla-dbus-access
+    --enable-jolla-dbus-access \
+    --enable-gatt
 
 make %{?jobs:-j%jobs}
 


### PR DESCRIPTION
This fixes a regression in the support for Low Energy bluetooth devices. See
https://bugs.launchpad.net/ubuntu/+source/bluez/+bug/1055616