### PR TITLE
[bluez] Read DI version ID from operating system

### DIFF
--- a/bluez/Makefile.am
+++ b/bluez/Makefile.am
@@ -277,6 +277,11 @@ builtin_modules += jolla_dbus_access
 builtin_sources += plugins/jolla-dbus-access.c
 endif
 
+if JOLLADIDPLUGIN
+builtin_modules += jolla_did
+builtin_sources += plugins/jolla-did.c
+endif
+
 if MAINTAINER_MODE
 plugin_LTLIBRARIES += plugins/external-dummy.la
 plugins_external_dummy_la_SOURCES = plugins/external-dummy.c

--- a/bluez/acinclude.m4
+++ b/bluez/acinclude.m4
@@ -204,6 +204,7 @@ AC_DEFUN([AC_ARG_BLUEZ], [
 	wiimote_enable=no
 	gatt_enable=no
 	jolla_dbus_access_enable=no
+	jolla_did=no
 
 	AC_ARG_ENABLE(optimization, AC_HELP_STRING([--disable-optimization], [disable code optimization]), [
 		optimization_enable=${enableval}
@@ -344,6 +345,10 @@ AC_DEFUN([AC_ARG_BLUEZ], [
 		jolla_dbus_access_enable=${enableval}
 	])
 
+	AC_ARG_ENABLE(jolla_did, AC_HELP_STRING([--enable-jolla-did], [compile with Jolla device ID plugin]), [
+		jolla_did_enable=${enableval}
+	])
+
 	misc_cflags=""
 	misc_ldflags=""
 
@@ -404,4 +409,5 @@ AC_DEFUN([AC_ARG_BLUEZ], [
 	AM_CONDITIONAL(WIIMOTEPLUGIN, test "${wiimote_enable}" = "yes")
 	AM_CONDITIONAL(GATTMODULES, test "${gatt_enable}" = "yes")
 	AM_CONDITIONAL(JOLLADBUSACCESSPLUGIN, test "${jolla_dbus_access_enable}" = "yes")
+	AM_CONDITIONAL(JOLLADIDPLUGIN, test "${jolla_did_enable}" = "yes")
 ])

--- a/bluez/plugins/jolla-did.c
+++ b/bluez/plugins/jolla-did.c
@@ -1,0 +1,309 @@
+/*
+ *
+ *  BlueZ - Bluetooth protocol stack for Linux
+ *
+ *  Copyright (C) 2015 Jolla Ltd. All rights reserved.
+ *  Contact: Hannu Mallat <hannu.mallat@jollamobile.com>
+ *
+ *  This program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ */
+
+/* Plugin for reading software version dynamically; used for DI
+   profile version ID. Note that DI profile vendor and product IDs are
+   always static and assigned in src/main.c:parse_did() outside of
+   this plugin */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <ctype.h>
+#include <glib.h>
+
+#include "plugin.h"
+#include "log.h"
+#include "hcid.h"
+#include "adapter.h"
+#include "manager.h"
+#include "sdpd.h"
+
+static GKeyFile *load_config(const char *file)
+{
+	GError *err = NULL;
+	GKeyFile *keyfile;
+
+	keyfile = g_key_file_new();
+
+	g_key_file_set_list_separator(keyfile, ',');
+
+	if (!g_key_file_load_from_file(keyfile, file, 0, &err)) {
+		error("Parsing %s failed: %s", file, err->message);
+		g_error_free(err);
+		g_key_file_free(keyfile);
+		return NULL;
+	}
+
+	return keyfile;
+}
+
+/* Would be nice if there was a proper BNF for /etc/os-release */
+
+static gsize skip_whitespace(gchar *buf, gsize len, gsize pos)
+{
+	gsize cur = pos;
+	while (cur < len && (buf[cur] == ' ' || buf[cur] == '\t'))
+		cur++;
+	return cur - pos;
+}
+
+static gsize skip_until_eol(gchar *buf, gsize len, gsize pos)
+{
+	gsize cur = pos;
+	while (cur < len && buf[cur] != '\n')
+		cur++;
+	return cur - pos;
+}
+
+static gsize expect_char(gchar *buf, gsize len, gsize pos, gchar val)
+{
+	if (pos >= len || buf[pos] != val)
+		return -1;
+	return 1;
+}
+
+#define FIRST_CHAR 0x1
+#define REST_CHAR 0x2
+
+static gsize read_variable_name(gchar *buf, gsize len, gsize pos)
+{
+	static uint8_t name_chars[256];
+	static gboolean name_chars_inited = FALSE;
+	gsize cur = pos;
+
+	if (!name_chars_inited) {
+		int i;
+		memset(name_chars, 0, sizeof(name_chars));
+		name_chars[(int)'_'] = FIRST_CHAR | REST_CHAR;
+		for (i = 'A'; i <= 'Z'; i++)
+			name_chars[i] = FIRST_CHAR | REST_CHAR;
+		for (i = 'a'; i <= 'z'; i++)
+			name_chars[i] = FIRST_CHAR | REST_CHAR;
+		for (i = '0'; i <= '9'; i++)
+			name_chars[i] = REST_CHAR;
+		name_chars_inited = TRUE;
+	}
+
+	if (cur >= len || !(name_chars[(int)buf[cur]] & FIRST_CHAR))
+		return -1;
+
+	cur++;
+	while (cur < len && (name_chars[(int)buf[cur]] & REST_CHAR))
+		cur++;
+
+	return cur - pos;
+}
+
+static gsize read_line(GHashTable *hash, gchar *buf, gsize len, gsize pos)
+{
+	gsize cur = pos;
+	gsize chunk;
+	gchar *name = NULL;
+	gchar *value = NULL;
+
+	if (buf[cur] == '#') {
+		cur += skip_until_eol(buf, len, cur);
+		cur++;
+		goto out;
+	}
+
+	cur += skip_whitespace(buf, len, cur);
+
+	chunk = read_variable_name(buf, len, cur);
+	if (chunk < 0) {
+		warn("Invalid name at position %u, skipping line", cur);
+		cur += skip_until_eol(buf, len, cur);
+		cur++;
+		goto out;
+	}
+	name = g_strndup(&buf[cur], chunk);
+	DBG("Found variable name '%s'", name);
+	cur += chunk;
+
+	chunk = expect_char(buf, len, cur, '=');
+	if (chunk < 0) {
+		warn("Assignment not found at position %u, skipping line", cur);
+		cur += skip_until_eol(buf, len, cur);
+		cur++;
+		goto out;
+	}
+	cur += chunk;
+
+	chunk = skip_until_eol(buf, len, cur);
+	value = g_strndup(&buf[cur], chunk);
+	DBG("Found unprocessed variable value '%s'", value);
+	cur += chunk;
+	cur++;
+
+	g_hash_table_replace(hash, name, value);
+	name = NULL;
+	value = NULL;
+
+out:
+	g_free(name);
+	g_free(value);
+	return MIN(len, cur) - pos;
+}
+
+static GHashTable *load_os_release(void)
+{
+	GHashTable *hash = NULL, *result = NULL;
+	gchar *buf = NULL;
+	gsize len = 0;
+	gsize pos = 0;
+
+	if (!g_file_get_contents("/etc/os-release", &buf, &len, NULL)) {
+		error("Cannot read /etc/os-release");
+		goto cleanup;
+	}
+
+	hash = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_free);
+
+	while (pos < len) {
+		gsize chunk = read_line(hash, buf, len, pos);
+		if (!chunk) {
+			error("Error parsing /etc/os-release (offset %u)", pos);
+			goto cleanup;
+		}
+		pos += chunk;
+	}
+
+	result = hash;
+	hash = NULL;
+
+cleanup:
+	if (hash)
+		g_hash_table_destroy(hash);
+
+	g_free(buf);
+
+	return result;
+}
+
+static int os_version(unsigned int *maj,
+			unsigned int *min,
+			unsigned int *sub,
+			unsigned int *bld)
+{
+	GHashTable *hash = NULL;
+	char *verstr = NULL;
+	int r = -1;
+
+	hash = load_os_release();
+	if (!hash) {
+		error("Cannot read OS version");
+		goto out;
+	}
+
+	verstr = g_hash_table_lookup(hash, "VERSION_ID");
+	if (!verstr) {
+		error("No VERSION_ID found");
+		goto out;
+	}
+
+	DBG("Read version string '%s'", verstr);
+
+	*maj = *min = *sub = *bld = 0;
+	if (sscanf(verstr, " %u.%u.%u.%u", maj, min, sub, bld) < 3) {
+		error("Cannot fully parse version string '%s'", verstr);
+	} else {
+		DBG("Version %u.%u.%u.%u", *maj, *min, *sub, *bld);
+		r = 0;
+	}
+
+out:
+	if (hash)
+		g_hash_table_destroy(hash);
+
+	return r;
+}
+
+static void set_did(struct btd_adapter *adapter, gpointer user_data)
+{
+	(void) user_data;
+
+	DBG("%p", adapter);
+	if (main_opts.did_source)
+		btd_adapter_set_did(adapter, main_opts.did_vendor,
+					main_opts.did_product,
+					main_opts.did_version,
+					main_opts.did_source);
+}
+
+static int jolla_did_init(void)
+{
+	GKeyFile *config;
+	gboolean dynver = FALSE;
+
+	DBG("");
+
+	config = load_config(CONFIGDIR "/jolla.conf");
+	if (config) {
+		dynver = g_key_file_get_boolean(config, "General",
+						"DeviceIDDynamicVersion", NULL);
+		g_key_file_free(config);
+	}
+
+	DBG("Dynamic DI version %sconfigured.", dynver ? "" : "not ");
+
+	if (dynver) {
+		unsigned int maj, min, sub, bld;
+		if (!os_version(&maj, &min, &sub, &bld)) {
+			uint16_t bcd = 0;
+			if (maj > 99 || min > 9 || sub > 9)
+				error("Clamping BCD for OS version %u.%u.%u",
+					maj, min, sub);
+			bcd |= MIN(maj/10, 9) << 12;
+			bcd |= MIN(maj%10, 9) << 8;
+			bcd |= MIN(min, 9) << 4;
+			bcd |= MIN(sub, 9);
+			DBG("Setting version ID to %04x", bcd);
+			main_opts.did_version = bcd;
+
+			/* Need to push the version to adapters (for
+			   EIR) as well as SDP server */
+
+			manager_foreach_adapter(set_did, NULL);
+			update_device_id();
+
+		} else {
+			error("Cannot get OS version");
+		}
+	}
+
+	return 0;
+}
+
+static void jolla_did_exit(void)
+{
+}
+
+BLUETOOTH_PLUGIN_DEFINE(jolla_did, VERSION,
+			BLUETOOTH_PLUGIN_PRIORITY_DEFAULT,
+			jolla_did_init, jolla_did_exit)
+

--- a/bluez/src/sdpd-service.c
+++ b/bluez/src/sdpd-service.c
@@ -231,6 +231,26 @@ void register_device_id(void)
 	update_db_timestamp();
 }
 
+void update_device_id(void)
+{
+	sdp_list_t *list;
+	uuid_t uuid;
+
+	sdp_uuid16_create(&uuid, PNP_INFO_SVCLASS_ID);
+
+	for (list = sdp_get_record_list(); list; list = list->next) {
+		sdp_record_t *rec = list->data;
+		if (!sdp_uuid_cmp(&uuid, &rec->svclass)) {
+			DBG("Removing old DI record (handle %d)", rec->handle);
+			remove_record_from_server(rec->handle);
+			break;
+		}
+
+	}
+
+	register_device_id();
+}
+
 int add_record_to_server(const bdaddr_t *src, sdp_record_t *rec)
 {
 	sdp_data_t *data;

--- a/bluez/src/sdpd.h
+++ b/bluez/src/sdpd.h
@@ -54,6 +54,7 @@ int service_remove_req(sdp_req_t *req, sdp_buf_t *rsp);
 void register_public_browse_group(void);
 void register_server_service(void);
 void register_device_id(void);
+void update_device_id(void);
 
 int record_sort(const void *r1, const void *r2);
 void sdp_svcdb_reset(void);

--- a/rpm/bluez.spec
+++ b/rpm/bluez.spec
@@ -155,7 +155,8 @@ This package provides default configs for bluez
     --with-telephony=ofono \
     --with-systemdunitdir=/lib/systemd/system \
     --enable-jolla-dbus-access \
-    --enable-gatt
+    --enable-gatt \
+    --enable-jolla-did
 
 make %{?jobs:-j%jobs}
 


### PR DESCRIPTION
Upstream DI implementation supports only a version ID which is
statically defined in main.conf; created a plugin which picks the
version ID from the operating system by parsing /etc/os-release.

Implemented only a minimal parser for /etc/os-release, which however
should be enough for reading the release version information.

Other components of DI information, namely vendor and product IDs, are
still read from main.conf as usual.