### PR TITLE
[bluez] Re-authenticate after link key rejection for paired device

### DIFF
--- a/bluez/src/device.c
+++ b/bluez/src/device.c
@@ -2578,6 +2578,21 @@ void device_bonding_complete(struct btd_device *device, uint8_t status)
 	if (status) {
 		device_cancel_authentication(device, TRUE);
 		device_cancel_bonding(device, status);
+
+		if (status == HCI_PIN_OR_KEY_MISSING && device_is_paired(device)) {
+			struct agent *agent = device_get_agent(device);
+			if (agent) {
+				uint8_t cap = agent_get_io_capability(agent);
+				DBG("Trying to recreate bonding.");
+				device_set_paired(device, FALSE);
+				device_set_bonded(device, FALSE);
+				adapter_create_bonding(device->adapter,
+						&device->bdaddr,
+						device->bdaddr_type,
+						cap);
+			}
+		}
+
 		return;
 	}
 


### PR DESCRIPTION
If we try to connect to a paired device and receive a link key error,
most probably that is because the remote end has removed the pairing
but we still have the now invalid key. Force renewed pairing via the
user agent in such a case.