### PR TITLE
[bluez] Require BT kernel subsystem for starting service

### DIFF
--- a/bluez/src/bluetooth.service.in
+++ b/bluez/src/bluetooth.service.in
@@ -2,6 +2,7 @@
 Description=Bluetooth service
 After=connman.service
 ConditionPathExists=!/run/systemd/boot-status/ACT_DEAD
+ConditionPathIsDirectory=/sys/kernel/debug/bluetooth
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Detect the presence of BT subsystem in the kernel by checking sysfs,
and do not start the systemd service if it's not present.