### PR TITLE
[bluez] Always have an AVRCP player ready

### DIFF
--- a/bluez/audio/avrcp.c
+++ b/bluez/audio/avrcp.c
@@ -414,7 +414,7 @@ int avrcp_player_event(struct avrcp_player *player, uint8_t id, void *data)
 	uint16_t size;
 	int err;
 
-	if (player->session == NULL)
+	if (!player || player->session == NULL)
 		return -ENOTCONN;
 
 	if (!(player->registered_events & (1 << id)))


### PR DESCRIPTION
Upstream code loses AVRCP PGUs like notification registrations if
there is no registered MediaPlayer at the time AVCTP connection is
made; there will not be a handler for those PDUs present. As a result,
headsets may not work as expected if there is no player running when
they connect.

Modified the code so that an AVRCP player is created on first AVCTP
connection, and it is not tied to any MediaPlayer. If there are no
MediaPlayers present, dummy answers will be given to requests;
otherwise requests are proxied to the first registered MediaPlayer.