### PR TITLE
[bluez] Check null D-Bus message pointer

### DIFF
--- a/bluez/src/device.c
+++ b/bluez/src/device.c
@@ -737,6 +737,9 @@ static void discover_services_reply(struct browse_req *req, int err,
 	DBusMessageIter iter, dict;
 	sdp_list_t *seq;
 
+	if (!req->msg)
+		return;
+
 	if (err) {
 		const char *err_if;
 


### PR DESCRIPTION
Self-spawned service discovery won't have a D-Bus method call to reply
to, so check the pointer before attempting to create a reply.