### PR TITLE
[bluez] Handle disconnected-connected state transition

### DIFF
--- a/bluez/audio/device.c
+++ b/bluez/audio/device.c
@@ -247,7 +247,8 @@ static void device_set_state(struct audio_device *dev, audio_state_t new_state)
 							priv->dc_id);
 			priv->dc_id = 0;
 		}
-	} else if (new_state == AUDIO_STATE_CONNECTING)
+	} else if (new_state == AUDIO_STATE_CONNECTING ||
+			(new_state == AUDIO_STATE_CONNECTED && !priv->dc_id))
 		priv->dc_id = device_add_disconnect_watch(dev->btd_dev,
 						disconnect_cb, dev, NULL);
 


### PR DESCRIPTION
Some D-Bus clients of the BlueZ API are not able to handle a direct
transition from sink state disconnected to connected, so added dummy
signaling of the intermediate connecting state when a state transition
from disconnected to connected happens.

Also, make sure device disconnection watch is registered also if
audio device state transition from disconnected to connected happens.