### PR TITLE
[bluez] Emit name changes also when adapter is down. Fixes MER#899.

### DIFF
--- a/bluez/src/adapter.c
+++ b/bluez/src/adapter.c
@@ -746,8 +746,9 @@ int adapter_set_name(struct btd_adapter *adapter, const char *name)
 		if (err < 0)
 			return err;
 	} else {
-		g_free(adapter->name);
-		adapter->name = g_strdup(maxname);
+		/* There won't be any HCI response to trigger a name
+		   change signal when adapter is down, so force it */
+		adapter_name_changed(adapter, maxname);
 	}
 
 	write_local_name(&adapter->bdaddr, maxname);


### PR DESCRIPTION
If an adapter is down when its name property is changed, there won't
be a HCI command response for local name change that triggers sending
a property change signal.

Changed the code to send the signal immediately when the new name
string is stored internally if the adapter is down.