### PR TITLE
[bluez] Don't reference pointer after deallocation. Fixes MER#905.

### DIFF
--- a/bluez/plugins/jolla-dbus-access.c
+++ b/bluez/plugins/jolla-dbus-access.c
@@ -108,9 +108,9 @@ static void busname_exit_callback(DBusConnection *conn, void *user_data)
 {
 	char *busname = user_data;
 	DBG("D-Bus name '%s' gone.", busname);
-	g_hash_table_remove(watch_hash, busname);
 	g_hash_table_remove(gid_hash, busname);
 	g_hash_table_remove(uid_hash, busname);
+	g_hash_table_remove(watch_hash, busname);
 }
 
 static void pid_query_result(DBusPendingCall *pend,


### PR DESCRIPTION
Re-ordered code so that call which causes user data pointer to be
deallocated is at the end of the callback function.