### PR TITLE
[bluez] Enable closing of AVDTP connections with an abort request. Fixes...

### DIFF
--- a/bluez/audio/avdtp.c
+++ b/bluez/audio/avdtp.c
@@ -3747,7 +3747,7 @@ int avdtp_close(struct avdtp *session, struct avdtp_stream *stream,
 		return -EINVAL;
 	}
 
-	if (immediate && session->req && stream == session->req->stream)
+	if (immediate)
 		return avdtp_abort(session, stream);
 
 	memset(&req, 0, sizeof(req));

--- a/bluez/doc/audio-api.txt
+++ b/bluez/doc/audio-api.txt
@@ -233,6 +233,14 @@ Methods		void Connect()
 
 			Possible Errors: org.bluez.Error.InvalidArguments
 
+		void SetProperty(string name, variant value)
+
+			Changes the value of the specified property. Only
+			properties that are listed a read-write are changeable.
+			On success this will emit a PropertyChanged signal.
+
+			Possible Errors: org.bluez.Error.InvalidArguments
+
 Signals		void Connected() {deprecated}
 
 			Sent when a successful connection has been made to the
@@ -290,6 +298,11 @@ properties	string State [readonly]
 			Indicates if a stream is active to a A2DP sink on
 			the remote device.
 
+		boolean ImmediateDisconnect  [readwrite]
+
+			Indicates if a stream disconnection is done
+			immediately (with abort) or normally.
+
 AudioSource hierarchy
 =====================
 
@@ -342,7 +355,6 @@ properties	string State [readonly]
 			"connected" -> "disconnected"
 			"playing" -> "disconnected"
 				Disconnected from the remote device
-
 
 HeadsetGateway hierarchy
 ========================


### PR DESCRIPTION
... MER#912.

To pass a PTS test related to sending an abort, define a D-Bus
property for audio sink that controls whether connection is closed
normally with a close request, or with an abort request.