### PR TITLE
[bluez] Ring indicator fix for connecting devices. Fixes MER#1008.

### DIFF
--- a/bluez/audio/telephony-ofono.c
+++ b/bluez/audio/telephony-ofono.c
@@ -233,7 +233,7 @@ void telephony_device_connected(void *telephony_device)
 
 	DBG("telephony-ofono: device %p connected", telephony_device);
 
-	coming = find_vc_with_status(CALL_STATUS_ALERTING);
+	coming = find_vc_with_status(CALL_STATUS_INCOMING);
 	if (coming) {
 		if (find_vc_with_status(CALL_STATUS_ACTIVE))
 			telephony_call_waiting_ind(coming->number,


### PR DESCRIPTION
If a headset connects during call setup, unsolicited RING codes should
be sent when there are incoming calls, not outgoing alerting ones.