### PR TITLE
[bluez] Check sysfs for unknown bus types. Fixes MER#1313

### DIFF
--- a/bluez/lib/hci.h
+++ b/bluez/lib/hci.h
@@ -55,6 +55,7 @@ extern "C" {
 #define HCI_RS232	4
 #define HCI_PCI		5
 #define HCI_SDIO	6
+#define HCI_MAX_BUS	HCI_SDIO
 
 /* HCI controller types */
 #define HCI_BREDR	0x00


### PR DESCRIPTION
In case kernel returns a bus type unknown to HCI library code,
try to get the bus name from sysfs instead.