### PR TITLE
[bluez] Tune adapter name change handling. Fixes MER#1365.

### DIFF
--- a/bluez/plugins/hciops.c
+++ b/bluez/plugins/hciops.c
@@ -801,7 +801,8 @@ static gboolean init_adapter(int index)
 	if (mode == MODE_OFF) {
 		/* We might have a set local name op pending completion;
 		   force storing a name to the adapter before turning off */
-		update_name(index, dev->name);
+		if (g_strcmp0(dev->name, ""))
+			update_name(index, dev->name);
 		hciops_power_off(index);
 		goto done;
 	}

--- a/bluez/src/adapter.c
+++ b/bluez/src/adapter.c
@@ -743,8 +743,14 @@ int adapter_set_name(struct btd_adapter *adapter, const char *name)
 
 	if (adapter->up) {
 		int err = adapter_ops->set_name(adapter->dev_id, maxname);
-		if (err < 0)
-			return err;
+		if (err < 0) {
+			if (err == -ENETDOWN) {
+				/* Adapter actually down, handle as below */
+				adapter_name_changed(adapter, maxname);
+			} else {
+				return err;
+			}
+		}
 	} else {
 		/* There won't be any HCI response to trigger a name
 		   change signal when adapter is down, so force it */


### PR DESCRIPTION
In case adapter goes down while name is being set, handle it as name
setting for an adapter that is already down in the beginning of a name
setting; store the name locally and emit a D-Bus signal for the
property if necessary.
